### PR TITLE
Added a default window size to stop annoying bug from happening

### DIFF
--- a/client/src/main/java/rt4/client.java
+++ b/client/src/main/java/rt4/client.java
@@ -259,7 +259,7 @@ public final class client extends GameShell {
 			instance = c;
 			c.startApplication(modeWhat + 32, "runescape");
 			GameShell.frame.setLocation(40, 40);
-			GameShell.frame.setSize(768, 530); //set a reasonable size by default because in HD window gets too damn small
+			GameShell.frame.setSize(768, 530); //set a reasonable size by default
 		} catch (@Pc(167) Exception ex) {
 			TracingException.report(null, ex);
 		}

--- a/client/src/main/java/rt4/client.java
+++ b/client/src/main/java/rt4/client.java
@@ -259,6 +259,7 @@ public final class client extends GameShell {
 			instance = c;
 			c.startApplication(modeWhat + 32, "runescape");
 			GameShell.frame.setLocation(40, 40);
+			GameShell.frame.setSize(768, 530); //set a reasonable size by default because in HD window gets too damn small
 		} catch (@Pc(167) Exception ex) {
 			TracingException.report(null, ex);
 		}


### PR DESCRIPTION
There's this really annoying bug that keeps happening:

The window opens at this size, both SD and HD.
So I gave it a default size and it fixed the issue.

![image](https://user-images.githubusercontent.com/61421472/174445851-5d5c263c-c001-4f69-81fc-be241428b8a2.png)
