### PR TITLE
Audio/Command API Expansion

### DIFF
--- a/client/src/main/java/plugin/Plugin.java
+++ b/client/src/main/java/plugin/Plugin.java
@@ -44,7 +44,9 @@ public abstract class Plugin {
     public void OnXPUpdate(int skill, int xp) {}
 
     /**
-     * Update() is called once per tick, aka once every 600ms.
+     * Update() is called once every 1000 client loops.
+     * This should be used for things that do need to update occasionally during runtime,
+     * but don't need to update super often.
      */
     public void Update() {}
 

--- a/client/src/main/java/plugin/api/API.java
+++ b/client/src/main/java/plugin/api/API.java
@@ -257,4 +257,56 @@ public class API {
     public static void DispatchCommand(String command) {
         Cheat.sendCheatPacket(JagString.of(command));
     }
+
+    public static void PlaySound(int volume, int trackId, int delay) {
+        SoundPlayer.play(volume, trackId, delay);
+    }
+
+    public static void PlayMusic(int volume, int trackId) {
+        MidiPlayer.playFadeOut(trackId, client.js5Archive6, volume);
+    }
+
+    public static void PlayJingle(int jingleId) {
+        MusicPlayer.playJingle(-1, jingleId);
+    }
+
+    public static void SetMusicVolume(int volume) {
+        Preferences.musicVolume = volume;
+    }
+
+    public static int GetMusicVolume() {
+        return Preferences.musicVolume;
+    }
+
+    public static void SetSoundVolume(int volume) {
+        Preferences.soundEffectVolume = volume;
+    }
+
+    public static int GetSoundVolume() {
+        return Preferences.soundEffectVolume;
+    }
+
+    public static void SetAmbientVolume(int volume) {
+        Preferences.ambientSoundsVolume = volume;
+    }
+
+    public static int GetAmbientVolume() {
+        return Preferences.ambientSoundsVolume;
+    }
+
+    public static boolean IsMusicPlaying() {
+        return MidiPlayer.isPlaying();
+    }
+
+    public static boolean IsSoundPlaying() {
+        return SoundPlayer.size != 0;
+    }
+
+    public static void SendMessage(String message) {
+        Chat.add(JagString.EMPTY, 0, JagString.of(message));
+    }
+
+    public static void RequestNewSong() {
+        SoundPlayer.sendTrackEndPacket();
+    }
 }

--- a/client/src/main/java/plugin/api/API.java
+++ b/client/src/main/java/plugin/api/API.java
@@ -253,4 +253,8 @@ public class API {
     public static void SetVarbit(int varbitId, int value) {
         VarpDomain.setVarbitClient(varbitId, value);
     }
+
+    public static void DispatchCommand(String command) {
+        Cheat.sendCheatPacket(JagString.of(command));
+    }
 }

--- a/client/src/main/java/rt4/Cheat.java
+++ b/client/src/main/java/rt4/Cheat.java
@@ -235,9 +235,13 @@ public class Cheat {
 			PluginRepository.reloadPlugins();
 		}
 		//}
+		sendCheatPacket(arg0);
+	}
+
+	public static void sendCheatPacket(JagString commandLine) {
 		Protocol.outboundBuffer.p1isaac(44);
-		Protocol.outboundBuffer.p1(arg0.length() - 1);
-		Protocol.outboundBuffer.pjstr(arg0.substring(2));
+		Protocol.outboundBuffer.p1(commandLine.length() - 1);
+		Protocol.outboundBuffer.pjstr(commandLine.substring(2));
 	}
 
 }

--- a/client/src/main/java/rt4/SoundPlayer.java
+++ b/client/src/main/java/rt4/SoundPlayer.java
@@ -128,9 +128,13 @@ public class SoundPlayer {
 			}
 			MidiPlayer.jingle = false;
 		} else if (Preferences.musicVolume != 0 && MusicPlayer.groupId != -1 && !MidiPlayer.isPlaying()) {
-			Protocol.outboundBuffer.p1isaac(137);
-			Protocol.outboundBuffer.p4(MusicPlayer.groupId);
-			MusicPlayer.groupId = -1;
+			sendTrackEndPacket();
 		}
+	}
+
+	public static void sendTrackEndPacket() {
+		Protocol.outboundBuffer.p1isaac(137);
+		Protocol.outboundBuffer.p4(MusicPlayer.groupId);
+		MusicPlayer.groupId = -1;
 	}
 }

--- a/client/src/main/java/rt4/client.java
+++ b/client/src/main/java/rt4/client.java
@@ -1589,6 +1589,7 @@ public final class client extends GameShell {
 			@Pc(24) GregorianCalendar gregorianCalendar = new GregorianCalendar();
 			MiniMenu.gregorianDateSeed = gregorianCalendar.get(Calendar.HOUR_OF_DAY) * 600 + gregorianCalendar.get(Calendar.MINUTE) * 10 + gregorianCalendar.get(Calendar.SECOND) / 6;
 			aRandom1.setSeed(MiniMenu.gregorianDateSeed);
+			PluginRepository.Update();
 		}
 		this.js5NetworkLoop();
 		if (js5MasterIndex != null) {

--- a/plugin-playground/src/main/kotlin/AudioQOL/plugin.kt
+++ b/plugin-playground/src/main/kotlin/AudioQOL/plugin.kt
@@ -1,0 +1,67 @@
+package AudioQOL
+
+import plugin.Plugin
+import plugin.annotations.PluginMeta
+import plugin.api.API
+import plugin.api.FontColor
+import plugin.api.FontType
+import plugin.api.TextModifier
+import rt4.Keyboard
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+
+@PluginMeta(
+    author = "Ceikry",
+    description = "Provides some QOL for audio, including better settings persistence",
+    version = 1.0
+)
+class plugin : Plugin() {
+    var isMute = false
+    var lastVolumes: Triple<Int,Int,Int>? = null
+
+    override fun Update() {
+        if (isMute) return
+        API.StoreData("sound-vol", API.GetSoundVolume())
+        API.StoreData("music-vol", API.GetMusicVolume())
+        API.StoreData("amb-vol", API.GetAmbientVolume())
+    }
+
+    override fun Init() {
+        val soundVol = API.GetData("sound-vol") as? Int ?: 255
+        val musicVol = API.GetData("music-vol") as? Int ?: 127
+        val ambVol = API.GetData("amb-vol") as? Int ?: 127
+        API.SetMusicVolume(soundVol)
+        API.SetAmbientVolume(musicVol)
+        API.SetSoundVolume(ambVol)
+
+        API.AddKeyboardListener(object : KeyAdapter() {
+            override fun keyPressed(e: KeyEvent) {
+                if (API.IsKeyPressed(Keyboard.KEY_CTRL) && e.keyCode == KeyEvent.VK_M) {
+                    toggleMute()
+                }
+            }
+        })
+    }
+
+    private fun toggleMute() {
+        isMute = !isMute
+        if (isMute) {
+            lastVolumes = Triple(API.GetMusicVolume(), API.GetSoundVolume(), API.GetAmbientVolume())
+            API.SetMusicVolume(0)
+            API.SetSoundVolume(0)
+            API.SetAmbientVolume(0)
+            API.SendMessage("Audio Muted.")
+            if (API.IsMusicPlaying()) {
+                API.PlayMusic(0, -1)
+            }
+        } else {
+            API.SetMusicVolume(lastVolumes?.first ?: 255)
+            API.SetSoundVolume(lastVolumes?.second ?: 127)
+            API.SetAmbientVolume(lastVolumes?.third ?: 127)
+            API.SendMessage("Audio Unmuted.")
+            if ((lastVolumes?.first ?: 255) > 0) {
+                API.RequestNewSong()
+            }
+        }
+    }
+}

--- a/plugin-playground/src/main/kotlin/TabReply/plugin.kt
+++ b/plugin-playground/src/main/kotlin/TabReply/plugin.kt
@@ -1,0 +1,23 @@
+package TabReply
+
+import plugin.Plugin
+import plugin.annotations.PluginMeta
+import plugin.api.API
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+
+@PluginMeta (
+    author = "Ceikry",
+    description = "Allows you to press tab to reply to DMs.",
+    version = 1.0
+)
+class plugin : Plugin() {
+    override fun Init() {
+        API.AddKeyboardListener(object : KeyAdapter() {
+            override fun keyPressed(e: KeyEvent) {
+                if (e.keyCode == KeyEvent.VK_TAB)
+                    API.DispatchCommand("::reply")
+            }
+        })
+    }
+}


### PR DESCRIPTION
- Add ability to dispatch commands to the server to the API
- Add ability to get and set all volume types to the API
- Add the ability to explicitly play sounds, jingles and music to the API
- Changed Update() to call every 1000 client update cycles.
- Add plugin that listens for the tab key and dispatches the "reply" command (tab-to-reply)
- Add plugin that uses plugin storage to persist audio settings. Should address a common complaint where these settings don't persist correctly on some OSes. This plugin also allows toggling audio mute/unmute with Ctrl+m. 