### PR TITLE
Add EscClose plugin

### DIFF
--- a/plugin-playground/src/main/kotlin/EscClose/plugin.kt
+++ b/plugin-playground/src/main/kotlin/EscClose/plugin.kt
@@ -1,0 +1,23 @@
+package EscClose
+
+import plugin.Plugin
+import plugin.annotations.PluginMeta
+import plugin.api.API
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+
+@PluginMeta (
+    author = "Chisato",
+    description = "Allows you to use ESC in order to (safety) close the open interface/dialogue.",
+    version = 1.0
+)
+class plugin : Plugin() {
+    override fun Init() {
+        API.AddKeyboardListener(object : KeyAdapter() {
+            override fun keyPressed(e: KeyEvent) {
+                if (e.keyCode == KeyEvent.VK_ESCAPE)
+                    API.DispatchCommand("::xface")
+            }
+        })
+    }
+}


### PR DESCRIPTION
With the recent addition of the xface command to the 2009-server, this plugin will now "properly" work on the main 2009scape server.

Allows you to use ESC in order to (safety) close the open interface/dialogue.