### PR TITLE
Allow increasing render distance and zooming out farther (and a lot of deob)

### DIFF
--- a/client/src/main/java/plugin/Plugin.java
+++ b/client/src/main/java/plugin/Plugin.java
@@ -24,7 +24,7 @@ public abstract class Plugin {
     }
 
     /**
-     * Init() is called when the plugin is first loaded
+     * Init() is called when the plugin is first loaded and any time the window is resized
      */
     public void Init() {}
 

--- a/client/src/main/java/plugin/Plugin.java
+++ b/client/src/main/java/plugin/Plugin.java
@@ -29,8 +29,8 @@ public abstract class Plugin {
     public void Init() {}
 
     /**
-     * Update() is called by the client rendering loop so that plugins can draw information onto the screen.
-     * This will be called once per frame, meaning it is framerate bound.
+     * Update() is called once before every game loop so that plugins can grab inputs
+     * and update things that need to be drawn later.
      * @param deltaTime the time (ms) elapsed since the last update call.
      */
     public void Update(long deltaTime) {}

--- a/client/src/main/java/plugin/Plugin.java
+++ b/client/src/main/java/plugin/Plugin.java
@@ -4,7 +4,6 @@ import plugin.api.MiniMenuEntry;
 import rt4.Component;
 import rt4.Npc;
 import rt4.Player;
-import rt4.Tile;
 
 /**
  * The base plugin class which is meant to be extended by plugins.
@@ -12,24 +11,17 @@ import rt4.Tile;
  * @author ceikry
  */
 public abstract class Plugin {
-    long timeOfLastDraw;
+    long timeOfLastUpdate;
 
     void _init() {
         Init();
     }
 
-    void _draw() {
+    void _update() {
         long nowTime = System.currentTimeMillis();
-        Draw(nowTime - timeOfLastDraw);
-        timeOfLastDraw = nowTime;
+        Update(nowTime - timeOfLastUpdate);
+        timeOfLastUpdate = nowTime;
     }
-
-    /**
-     * Draw() is called by the client rendering loop so that plugins can draw information onto the screen.
-     * This will be called once per frame, meaning it is framerate bound.
-     * @param timeDelta the time (ms) elapsed since the last draw call.
-     */
-    public void Draw(long timeDelta) {}
 
     /**
      * Init() is called when the plugin is first loaded
@@ -37,18 +29,31 @@ public abstract class Plugin {
     public void Init() {}
 
     /**
+     * Update() is called by the client rendering loop so that plugins can draw information onto the screen.
+     * This will be called once per frame, meaning it is framerate bound.
+     * @param deltaTime the time (ms) elapsed since the last update call.
+     */
+    public void Update(long deltaTime) {}
+
+    /**
+     * Draw() is called by the client rendering loop so that plugins can draw information onto the screen.
+     * This will be called once per frame, meaning it is framerate bound.
+     */
+    public void Draw() {}
+
+    /**
+     * Tick() is called once every 1000 client loops.
+     * This should be used for things that do need to update occasionally during runtime,
+     * but don't need to update super often.
+     */
+    public void Tick() {}
+
+    /**
      * OnXPUpdate() is called when the client receives an XP update packet. This includes at login.
      * @param skill - the skill ID being updated
      * @param xp - the new total XP for the skill.
      */
     public void OnXPUpdate(int skill, int xp) {}
-
-    /**
-     * Update() is called once every 1000 client loops.
-     * This should be used for things that do need to update occasionally during runtime,
-     * but don't need to update super often.
-     */
-    public void Update() {}
 
     /**
      * PlayerOverheadDraw() is called once per frame, for every player on the screen. :) Expensive.

--- a/client/src/main/java/plugin/PluginRepository.java
+++ b/client/src/main/java/plugin/PluginRepository.java
@@ -2,12 +2,10 @@ package plugin;
 
 import plugin.api.API;
 import plugin.api.MiniMenuEntry;
-import plugin.api.MiniMenuType;
 import rt4.*;
 
 import java.awt.event.KeyAdapter;
 import java.awt.event.MouseAdapter;
-import java.awt.event.MouseListener;
 import java.awt.event.MouseWheelListener;
 import java.io.*;
 import java.net.URL;
@@ -130,13 +128,16 @@ public class PluginRepository {
             e.printStackTrace();
         }
     }
-
     public static void Update() {
-        loadedPlugins.values().forEach(Plugin::Update);
+        loadedPlugins.values().forEach(Plugin::_update);
     }
 
     public static void Draw() {
-        loadedPlugins.values().forEach(Plugin::_draw);
+        loadedPlugins.values().forEach(Plugin::Draw);
+    }
+
+    public static void Tick() {
+        loadedPlugins.values().forEach(Plugin::Tick);
     }
 
     public static void NPCOverheadDraw(Npc npc, int screenX, int screenY) {

--- a/client/src/main/java/plugin/PluginRepository.java
+++ b/client/src/main/java/plugin/PluginRepository.java
@@ -180,6 +180,6 @@ public class PluginRepository {
     }
 
     public static void OnLogin() {
-        loadedPlugins.values().forEach((plugin) -> plugin.OnLogin());
+        loadedPlugins.values().forEach(Plugin::OnLogin);
     }
 }

--- a/client/src/main/java/plugin/api/API.java
+++ b/client/src/main/java/plugin/api/API.java
@@ -171,12 +171,20 @@ public class API {
         return Camera.pitchTarget;
     }
 
+    public static void UpdateCameraZoom(int zoomDiff, int min, int max) {
+        Camera.ZOOM = clamp(min, max, Camera.ZOOM + (zoomDiff >= 0 ? 50 : -50));
+    }
+
     public static void UpdateCameraZoom(int zoomDiff) {
-        Camera.ZOOM = clamp(200, 1200, Camera.ZOOM + (zoomDiff >= 0 ? 50 : -50));
+        UpdateCameraZoom(zoomDiff, 200, 1200);
+    }
+
+    public static void SetCameraZoom(int zoomTarget, int min, int max) {
+        Camera.ZOOM = clamp(min, max, zoomTarget);
     }
 
     public static void SetCameraZoom(int zoomTarget) {
-        Camera.ZOOM = clamp(200, 1200, zoomTarget);
+        SetCameraZoom(zoomTarget, 200, 1200);
     }
 
     public static int GetCameraZoom() {

--- a/client/src/main/java/rt4/Camera.java
+++ b/client/src/main/java/rt4/Camera.java
@@ -88,7 +88,7 @@ public class Camera {
 	@OriginalMember(owner = "client!sj", name = "H", descriptor = "I")
 	public static int anInt5161 = 0;
 	@OriginalMember(owner = "client!af", name = "d", descriptor = "I")
-	public static int anInt40;
+	public static int renderY;
 	@OriginalMember(owner = "client!lg", name = "d", descriptor = "F")
 	public static float aFloat15;
 	@OriginalMember(owner = "client!sk", name = "jb", descriptor = "I")
@@ -120,7 +120,7 @@ public class Camera {
 			for (local64 = local33 - 4; local64 <= local33 + 4; local64++) {
 				for (@Pc(73) int local73 = local37 - 4; local73 <= local37 + 4; local73++) {
 					@Pc(80) int local80 = Player.plane;
-					if (local80 < 3 && (SceneGraph.renderFlags[1][local64][local73] & 0x2) == 2) {
+					if (local80 < 3 && (SceneGraph.tileRenderFlags[1][local64][local73] & 0x2) == 2) {
 						local80++;
 					}
 					@Pc(117) int local117 = (SceneGraph.aByteArrayArrayArray13[local80][local64][local73] & 0xFF) * 8 + local43 - SceneGraph.tileHeights[local80][local64][local73];
@@ -152,7 +152,7 @@ public class Camera {
 		if (anInt4612 >= 100) {
 			renderX = anInt5375 * 128 + 64;
 			renderZ = anInt4232 * 128 + 64;
-			anInt40 = SceneGraph.getTileHeight(Player.plane, renderX, renderZ) - anInt5203;
+			renderY = SceneGraph.getTileHeight(Player.plane, renderX, renderZ) - anInt5203;
 		} else {
 			if (renderX < local15) {
 				renderX += anInt5225 + anInt4612 * (local15 - renderX) / 1000;
@@ -160,10 +160,10 @@ public class Camera {
 					renderX = local15;
 				}
 			}
-			if (anInt40 < local23) {
-				anInt40 += (local23 - anInt40) * anInt4612 / 1000 + anInt5225;
-				if (anInt40 > local23) {
-					anInt40 = local23;
+			if (renderY < local23) {
+				renderY += (local23 - renderY) * anInt4612 / 1000 + anInt5225;
+				if (renderY > local23) {
+					renderY = local23;
 				}
 			}
 			if (renderX > local15) {
@@ -178,10 +178,10 @@ public class Camera {
 					renderZ = local9;
 				}
 			}
-			if (local23 < anInt40) {
-				anInt40 -= (anInt40 - local23) * anInt4612 / 1000 + anInt5225;
-				if (local23 > anInt40) {
-					anInt40 = local23;
+			if (local23 < renderY) {
+				renderY -= (renderY - local23) * anInt4612 / 1000 + anInt5225;
+				if (local23 > renderY) {
+					renderY = local23;
 				}
 			}
 			if (renderZ > local9) {
@@ -194,7 +194,7 @@ public class Camera {
 		local9 = anInt5765 * 128 + 64;
 		local15 = anInt5449 * 128 + 64;
 		local23 = SceneGraph.getTileHeight(Player.plane, local15, local9) - anInt1744;
-		@Pc(236) int local236 = local23 - anInt40;
+		@Pc(236) int local236 = local23 - renderY;
 		@Pc(241) int local241 = local9 - renderZ;
 		@Pc(246) int local246 = local15 - renderX;
 		@Pc(257) int local257 = (int) Math.sqrt(local246 * local246 + local241 * local241);
@@ -280,7 +280,7 @@ public class Camera {
 			local173 = anIntArrayArrayArray9[anInt3718][local70 + 2][local72] + local131 - local119 - local111;
 			renderCoordinates[local72] = (float) local119 + (((float) local173 * local66 + (float) local155) * local66 + (float) local146) * local66;
 		}
-		anInt40 = (int) renderCoordinates[1] * -1;
+		renderY = (int) renderCoordinates[1] * -1;
 		renderX = (int) renderCoordinates[0] - originX * 128;
 		renderZ = (int) renderCoordinates[2] - originZ * 128;
 		@Pc(226) float[] local226 = new float[3];
@@ -316,7 +316,7 @@ public class Camera {
 			@Pc(30) int local30 = anInt5449 * 128 + 64;
 			@Pc(36) int local36 = anInt5765 * 128 + 64;
 			@Pc(44) int local44 = SceneGraph.getTileHeight(Player.plane, local30, local36) - anInt1744;
-			@Pc(49) int local49 = local44 - anInt40;
+			@Pc(49) int local49 = local44 - renderY;
 			@Pc(54) int local54 = local30 - renderX;
 			@Pc(59) int local59 = local36 - renderZ;
 			@Pc(70) int local70 = (int) Math.sqrt(local59 * local59 + local54 * local54);
@@ -342,7 +342,7 @@ public class Camera {
 		if (arg0 && anInt4612 >= 100) {
 			renderX = anInt5375 * 128 + 64;
 			renderZ = anInt4232 * 128 + 64;
-			anInt40 = SceneGraph.getTileHeight(Player.plane, renderX, renderZ) - anInt5203;
+			renderY = SceneGraph.getTileHeight(Player.plane, renderX, renderZ) - anInt5203;
 		}
 		cameraType = 2;
 	}
@@ -391,7 +391,7 @@ public class Camera {
 	}
 
 	@OriginalMember(owner = "client!bh", name = "a", descriptor = "(IIIIIIII)V")
-	public static void method555(@OriginalArg(0) int arg0, @OriginalArg(2) int arg1, @OriginalArg(3) int arg2, @OriginalArg(4) int arg3, @OriginalArg(5) int arg4, @OriginalArg(6) int arg5, @OriginalArg(7) int arg6) {
+	public static void convertOrbitCamToAbsolutePosition(@OriginalArg(0) int cameraX, @OriginalArg(2) int arg1, @OriginalArg(3) int cameraY, @OriginalArg(4) int zoom, @OriginalArg(5) int yaw, @OriginalArg(6) int cameraZ, @OriginalArg(7) int pitch) {
 		@Pc(5) int local5;
 		@Pc(29) int local29;
 		if (GlRenderer.enabled) {
@@ -402,20 +402,20 @@ public class Camera {
 				local5 = 100;
 			}
 			local29 = local5 * (ScriptRunner.aShort27 - ScriptRunner.aShort30) / 100 + ScriptRunner.aShort30;
-			arg3 = local29 * arg3 >> 8;
+			zoom = local29 * zoom >> 8;
 		}
-		local5 = 2048 - arg6 & 0x7FF;
-		local29 = 2048 - arg4 & 0x7FF;
+		local5 = 2048 - pitch & 0x7FF;
+		local29 = 2048 - yaw & 0x7FF;
 		@Pc(55) int local55 = 0;
-		@Pc(57) int local57 = arg3;
+		@Pc(57) int local57 = zoom;
 		@Pc(59) int local59 = 0;
 		@Pc(72) int local72;
 		@Pc(68) int local68;
 		if (local5 != 0) {
 			local68 = MathUtils.cos[local5];
 			local72 = MathUtils.sin[local5];
-			local59 = local72 * -arg3 >> 16;
-			local57 = local68 * arg3 >> 16;
+			local59 = local72 * -zoom >> 16;
+			local57 = local68 * zoom >> 16;
 		}
 		if (local29 != 0) {
 			local72 = MathUtils.sin[local29];
@@ -423,10 +423,10 @@ public class Camera {
 			local55 = local72 * local57 >> 16;
 			local57 = local57 * local68 >> 16;
 		}
-		cameraPitch = arg6;
-		cameraYaw = arg4;
-		renderZ = arg5 - local57;
-		renderX = arg0 - local55;
-		anInt40 = arg2 - local59;
+		cameraPitch = pitch;
+		cameraYaw = yaw;
+		renderZ = cameraZ - local57;
+		renderX = cameraX - local55;
+		renderY = cameraY - local59;
 	}
 }

--- a/client/src/main/java/rt4/Camera.java
+++ b/client/src/main/java/rt4/Camera.java
@@ -111,19 +111,22 @@ public class Camera {
 			pitchTarget = 383;
 		}
 		yawTarget = mod(yawTarget, 2047.0d);
-		@Pc(33) int local33 = cameraX >> 7;
-		@Pc(37) int local37 = cameraZ >> 7;
-		@Pc(43) int local43 = SceneGraph.getTileHeight(Player.plane, cameraX, cameraZ);
+		@Pc(33) int cameraTileX = cameraX >> 7;
+		@Pc(37) int cameraTileZ = cameraZ >> 7;
+		@Pc(43) int playerTileHeight = SceneGraph.getTileHeight(Player.plane, cameraX, cameraZ);
+		if (playerTileHeight <= 0) {
+			return;
+		}
 		@Pc(45) int local45 = 0;
 		@Pc(64) int local64;
-		if (local33 > 3 && local37 > 3 && local33 < 100 && local37 < 100) {
-			for (local64 = local33 - 4; local64 <= local33 + 4; local64++) {
-				for (@Pc(73) int local73 = local37 - 4; local73 <= local37 + 4; local73++) {
+		if (cameraTileX > 3 && cameraTileZ > 3 && cameraTileX < 100 && cameraTileZ < 100) {
+			for (local64 = cameraTileX - 4; local64 <= cameraTileX + 4; local64++) {
+				for (@Pc(73) int local73 = cameraTileZ - 4; local73 <= cameraTileZ + 4; local73++) {
 					@Pc(80) int local80 = Player.plane;
 					if (local80 < 3 && (SceneGraph.tileRenderFlags[1][local64][local73] & 0x2) == 2) {
 						local80++;
 					}
-					@Pc(117) int local117 = (SceneGraph.aByteArrayArrayArray13[local80][local64][local73] & 0xFF) * 8 + local43 - SceneGraph.tileHeights[local80][local64][local73];
+					@Pc(117) int local117 = (SceneGraph.aByteArrayArrayArray13[local80][local64][local73] & 0xFF) * 8 + playerTileHeight - SceneGraph.tileHeights[local80][local64][local73];
 					if (local117 > local45) {
 						local45 = local117;
 					}

--- a/client/src/main/java/rt4/Cs1ScriptRunner.java
+++ b/client/src/main/java/rt4/Cs1ScriptRunner.java
@@ -733,9 +733,9 @@ public class Cs1ScriptRunner {
 											SoftwareRaster.fillRectAlpha(local123, local114, component.width, component.height, local270, 256 - (alpha & 0xFF));
 										}
 									} else if (GlRenderer.enabled) {
-										GlRaster.method1180(local123, local114, component.width, component.height, local270, 256 - (alpha & 0xFF));
+										GlRaster.drawRectAlpha(local123, local114, component.width, component.height, local270, 256 - (alpha & 0xFF));
 									} else {
-										SoftwareRaster.method2487(local123, local114, component.width, component.height, local270, 256 - (alpha & 0xFF));
+										SoftwareRaster.drawRectAlpha(local123, local114, component.width, component.height, local270, 256 - (alpha & 0xFF));
 									}
 									PluginRepository.ComponentDraw(i, component, local123, local114);
 								} else {
@@ -798,7 +798,7 @@ public class Cs1ScriptRunner {
 													color = (component.height + local468 - 1) / local468;
 
 													if (GlRenderer.enabled) {
-														GlRaster.method1183(local123, local114, component.width + local123, component.height + local114);
+														GlRaster.shrinkClip(local123, local114, component.width + local123, component.height + local114);
 
 														@Pc(2274) boolean local2274 = IntUtils.isPowerOfTwo(sprite.width);
 														@Pc(2279) boolean local2279 = IntUtils.isPowerOfTwo(sprite.height);
@@ -958,7 +958,7 @@ public class Cs1ScriptRunner {
 													GlRenderer.setFogEnabled(false);
 													FogManager.init(Preferences.brightness);
 													if (ScriptRunner.aBoolean299) {
-														GlRaster.method1177();
+														GlRaster.setFullClip();
 														GlRenderer.clearDepthBuffer();
 														GlRaster.setClip(arg0, arg6, arg4, arg7);
 														ScriptRunner.aBoolean299 = false;
@@ -1097,14 +1097,14 @@ public class Cs1ScriptRunner {
 												}
 												if (component.lineWidth == 1) {
 													if (GlRenderer.enabled) {
-														GlRaster.method1185(local123, local276, local468, memory, component.color);
+														GlRaster.renderLine(local123, local276, local468, memory, component.color);
 													} else {
-														SoftwareRaster.method2500(local123, local276, local468, memory, component.color);
+														SoftwareRaster.renderLine(local123, local276, local468, memory, component.color);
 													}
 												} else if (GlRenderer.enabled) {
-													GlRaster.method1181(local123, local276, local468, memory, component.color, component.lineWidth);
+													GlRaster.renderLine(local123, local276, local468, memory, component.color, component.lineWidth);
 												} else {
-													SoftwareRaster.method2494(local123, local276, local468, memory, component.color, component.lineWidth);
+													SoftwareRaster.renderLine(local123, local276, local468, memory, component.color, component.lineWidth);
 												}
 												PluginRepository.ComponentDraw(i, component, local468, local276);
 											}
@@ -1188,14 +1188,14 @@ public class Cs1ScriptRunner {
 		}
 		GlRaster.fillRect(arg2, arg3 + 16, 16, arg4 - 32, anInt4306);
 		GlRaster.fillRect(arg2, arg3 + local54 + 16, 16, local35, anInt1704);
-		GlRaster.method1176(arg2, local54 + arg3 + 16, local35, anInt4938);
-		GlRaster.method1176(arg2 + 1, local54 + 16 + arg3, local35, anInt4938);
-		GlRaster.method1174(arg2, local54 + arg3 + 16, 16, anInt4938);
-		GlRaster.method1174(arg2, local54 + arg3 + 17, 16, anInt4938);
-		GlRaster.method1176(arg2 + 15, arg3 + (16 - -local54), local35, anInt671);
-		GlRaster.method1176(arg2 + 14, arg3 - -local54 + 17, local35 - 1, anInt671);
-		GlRaster.method1174(arg2, local35 + arg3 + local54 + 15, 16, anInt671);
-		GlRaster.method1174(arg2 + 1, arg3 + 14 - -local54 + local35, 15, anInt671);
+		GlRaster.drawVerticalLine(arg2, local54 + arg3 + 16, local35, anInt4938);
+		GlRaster.drawVerticalLine(arg2 + 1, local54 + 16 + arg3, local35, anInt4938);
+		GlRaster.drawHorizontalLine(arg2, local54 + arg3 + 16, 16, anInt4938);
+		GlRaster.drawHorizontalLine(arg2, local54 + arg3 + 17, 16, anInt4938);
+		GlRaster.drawVerticalLine(arg2 + 15, arg3 + (16 - -local54), local35, anInt671);
+		GlRaster.drawVerticalLine(arg2 + 14, arg3 - -local54 + 17, local35 - 1, anInt671);
+		GlRaster.drawHorizontalLine(arg2, local35 + arg3 + local54 + 15, 16, anInt671);
+		GlRaster.drawHorizontalLine(arg2 + 1, arg3 + 14 - -local54 + local35, 15, anInt671);
 	}
 
 	@OriginalMember(owner = "client!aa", name = "a", descriptor = "(BLclient!be;)V")

--- a/client/src/main/java/rt4/Cs1ScriptRunner.java
+++ b/client/src/main/java/rt4/Cs1ScriptRunner.java
@@ -389,7 +389,7 @@ public class Cs1ScriptRunner {
 								InterfaceList.aClass13_26 = component;
 								InterfaceList.anInt5574 = local114;
 								anInt2503 = local123;
-								ScriptRunner.method4326(component.height, component.clientCode == 1403, local123, component.width, local114);
+								ScriptRunner.renderComponent(component.height, component.clientCode == 1403, local123, component.width, local114);
 								if (GlRenderer.enabled) {
 									GlRaster.setClip(arg0, arg6, arg4, arg7);
 								} else {

--- a/client/src/main/java/rt4/FogManager.java
+++ b/client/src/main/java/rt4/FogManager.java
@@ -218,38 +218,38 @@ public final class FogManager {
 	}
 
 	@OriginalMember(owner = "client!i", name = "b", descriptor = "(IIIII)I")
-	public static int method2235(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3) {
+	public static int fadeFog(@OriginalArg(0) int speed, @OriginalArg(1) int z, @OriginalArg(2) int brightness, @OriginalArg(3) int x) {
 		if (instantScreenFade) {
-			arg0 = 1000000;
+			speed = 1000000;
 			instantScreenFade = false;
 		}
-		@Pc(15) Environment local15 = chunksAtmosphere[arg3][arg1];
-		@Pc(25) float local25 = ((float) arg2 * 0.1F + 0.7F) * local15.lightModelAmbient;
-		@Pc(28) float local28 = local15.light0Diffuse;
-		@Pc(31) int local31 = local15.screenColorRgb;
-		@Pc(34) int local34 = local15.fogDepth;
-		@Pc(37) int local37 = local15.fogColorRgb;
+		@Pc(15) Environment environment = chunksAtmosphere[x][z];
+		@Pc(25) float fogBrightness = ((float) brightness * 0.1F + 0.7F) * environment.lightModelAmbient;
+		@Pc(28) float light0Diffuse = environment.light0Diffuse;
+		@Pc(31) int screenColorRgb = environment.screenColorRgb;
+		@Pc(34) int fogDepth = environment.fogDepth;
+		@Pc(37) int fogColor = environment.fogColorRgb;
 		if (!Preferences.fogEnabled) {
-			local34 = 0;
+			fogDepth = 0;
 		}
-		@Pc(44) float local44 = local15.light1Diffuse;
-		if (local31 != anInt2883 || aFloat13 != local25 || aFloat1 != local28 || local44 != aFloat4 || anInt4044 != local37 || anInt5080 != local34) {
-			aFloat13 = local25;
+		@Pc(44) float light1Diffuse = environment.light1Diffuse;
+		if (screenColorRgb != anInt2883 || aFloat13 != fogBrightness || aFloat1 != light0Diffuse || light1Diffuse != aFloat4 || anInt4044 != fogColor || anInt5080 != fogDepth) {
+			aFloat13 = fogBrightness;
 			aFloat37 = aFloat36;
 			aFloat6 = aFloat7;
-			anInt2883 = local31;
+			anInt2883 = screenColorRgb;
 			anInt4623 = anInt3709;
 			anInt4153 = anInt2161;
-			aFloat4 = local44;
+			aFloat4 = light1Diffuse;
 			anInt5868 = 0;
 			anInt3255 = anInt5731;
-			anInt5080 = local34;
-			aFloat1 = local28;
-			anInt4044 = local37;
+			anInt5080 = fogDepth;
+			aFloat1 = light0Diffuse;
+			anInt4044 = fogColor;
 			aFloat23 = aFloat5;
 		}
 		if (anInt5868 < 65536) {
-			anInt5868 += arg0 * 250;
+			anInt5868 += speed * 250;
 			if (anInt5868 >= 65536) {
 				anInt5868 = 65536;
 			}
@@ -277,19 +277,19 @@ public final class FogManager {
 	}
 
 	@OriginalMember(owner = "client!fm", name = "a", descriptor = "(ZII)V")
-	public static void setLightPosition(@OriginalArg(1) int arg0, @OriginalArg(2) int arg1) {
-		currentLightX = chunksAtmosphere[arg1][arg0].lightX;
-		currentLightY = chunksAtmosphere[arg1][arg0].lightY;
-		currentLightZ = chunksAtmosphere[arg1][arg0].lightZ;
+	public static void setLightPosition(@OriginalArg(1) int z, @OriginalArg(2) int x) {
+		currentLightX = chunksAtmosphere[x][z].lightX;
+		currentLightY = chunksAtmosphere[x][z].lightY;
+		currentLightZ = chunksAtmosphere[x][z].lightZ;
 		setLightPosition((float) currentLightX, (float) currentLightY, (float) currentLightZ);
 	}
 
 	@OriginalMember(owner = "client!g", name = "b", descriptor = "(I)V")
 	public static void setDefaultChunksAtmosphere() {
-		@Pc(9) Environment local9 = new Environment();
-		for (@Pc(18) int local18 = 0; local18 < 13; local18++) {
-			for (@Pc(25) int local25 = 0; local25 < 13; local25++) {
-				chunksAtmosphere[local18][local25] = local9;
+		@Pc(9) Environment defaultEnv = new Environment();
+		for (@Pc(18) int x = 0; x < 13; x++) {
+			for (@Pc(25) int z = 0; z < 13; z++) {
+				chunksAtmosphere[x][z] = defaultEnv;
 			}
 		}
 	}

--- a/client/src/main/java/rt4/Font.java
+++ b/client/src/main/java/rt4/Font.java
@@ -303,14 +303,14 @@ public abstract class Font extends SecondaryNode {
 					@Pc(323) int local323 = this.glyphWidths[local22];
 					if (strikethroughColor != -1) {
 						if (GlRenderer.enabled) {
-							GlRaster.method1174(arg1, local4 + (int) ((double) this.lineHeight * 0.7D), local323, strikethroughColor);
+							GlRaster.drawHorizontalLine(arg1, local4 + (int) ((double) this.lineHeight * 0.7D), local323, strikethroughColor);
 						} else {
 							SoftwareRaster.drawHorizontalLine(arg1, local4 + (int) ((double) this.lineHeight * 0.7D), local323, strikethroughColor);
 						}
 					}
 					if (underlineColor != -1) {
 						if (GlRenderer.enabled) {
-							GlRaster.method1174(arg1, local4 + this.lineHeight + 1, local323, underlineColor);
+							GlRaster.drawHorizontalLine(arg1, local4 + this.lineHeight + 1, local323, underlineColor);
 						} else {
 							SoftwareRaster.drawHorizontalLine(arg1, local4 + this.lineHeight + 1, local323, underlineColor);
 						}
@@ -995,14 +995,14 @@ public abstract class Font extends SecondaryNode {
 					@Pc(387) int local387 = this.glyphWidths[local24];
 					if (strikethroughColor != -1) {
 						if (GlRenderer.enabled) {
-							GlRaster.method1174(arg1, local4 + (int) ((double) this.lineHeight * 0.7D), local387, strikethroughColor);
+							GlRaster.drawHorizontalLine(arg1, local4 + (int) ((double) this.lineHeight * 0.7D), local387, strikethroughColor);
 						} else {
 							SoftwareRaster.drawHorizontalLine(arg1, local4 + (int) ((double) this.lineHeight * 0.7D), local387, strikethroughColor);
 						}
 					}
 					if (underlineColor != -1) {
 						if (GlRenderer.enabled) {
-							GlRaster.method1174(arg1, local4 + this.lineHeight, local387, underlineColor);
+							GlRaster.drawHorizontalLine(arg1, local4 + this.lineHeight, local387, underlineColor);
 						} else {
 							SoftwareRaster.drawHorizontalLine(arg1, local4 + this.lineHeight, local387, underlineColor);
 						}

--- a/client/src/main/java/rt4/GameShell.java
+++ b/client/src/main/java/rt4/GameShell.java
@@ -688,7 +688,7 @@ public abstract class GameShell extends Applet implements Runnable, FocusListene
 			frame.toFront();
 			@Pc(44) Insets insets = frame.getInsets();
 			frame.setSize(insets.left + frameWidth + insets.right, insets.top + frameHeight + insets.bottom);
-                        configureTargetFPS();
+			configureTargetFPS();
 			signLink2 = signLink = new SignLink(null, cacheId, cacheSubDir, 28);
 			@Pc(76) PrivilegedRequest request = signLink.startThread(1, this);
 			while (request.status == 0) {
@@ -700,13 +700,14 @@ public abstract class GameShell extends Applet implements Runnable, FocusListene
 		}
 	}
 
-        private final void configureTargetFPS() {
-            int refreshRate = getCurrentDevice().getDisplayMode().getRefreshRate();
-            if (refreshRate == java.awt.DisplayMode.REFRESH_RATE_UNKNOWN) {  
-                refreshRate = 60; //just assume 60hz and call it a day.
-            }
-            GameShell.setFpsTarget(refreshRate);
-        }
+	private final void configureTargetFPS()
+	{
+		int refreshRate = getCurrentDevice().getDisplayMode().getRefreshRate();
+		if (refreshRate == java.awt.DisplayMode.REFRESH_RATE_UNKNOWN) {
+			refreshRate = 60; //just assume 60hz and call it a day.
+		}
+		GameShell.setFpsTarget(refreshRate);
+	}
 
 	@OriginalMember(owner = "client!rc", name = "windowOpened", descriptor = "(Ljava/awt/event/WindowEvent;)V")
 	@Override

--- a/client/src/main/java/rt4/GlRaster.java
+++ b/client/src/main/java/rt4/GlRaster.java
@@ -220,15 +220,15 @@ public final class GlRaster {
 	}
 
 	@OriginalMember(owner = "client!dj", name = "c", descriptor = "(IIIII)V")
-	public static void fillRect(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
+	public static void fillRect(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int width, @OriginalArg(3) int height, @OriginalArg(4) int color) {
 		GlRenderer.method4162();
-		@Pc(3) float local3 = (float) arg0;
-		@Pc(8) float local8 = local3 + (float) arg2;
-		@Pc(13) float local13 = (float) (GlRenderer.canvasHeight - arg1);
-		@Pc(18) float local18 = local13 - (float) arg3;
+		@Pc(3) float local3 = (float) x;
+		@Pc(8) float local8 = local3 + (float) width;
+		@Pc(13) float local13 = (float) (GlRenderer.canvasHeight - y);
+		@Pc(18) float local18 = local13 - (float) height;
 		@Pc(20) GL2 local20 = GlRenderer.gl;
 		local20.glBegin(GL2.GL_TRIANGLE_FAN);
-		local20.glColor3ub((byte) (arg4 >> 16), (byte) (arg4 >> 8), (byte) arg4);
+		local20.glColor3ub((byte) (color >> 16), (byte) (color >> 8), (byte) color);
 		local20.glVertex2f(local3, local13);
 		local20.glVertex2f(local3, local18);
 		local20.glVertex2f(local8, local18);

--- a/client/src/main/java/rt4/GlRaster.java
+++ b/client/src/main/java/rt4/GlRaster.java
@@ -22,35 +22,35 @@ public final class GlRaster {
 	public static int clipBottom = 0;
 
 	@OriginalMember(owner = "client!dj", name = "a", descriptor = "(IIII)V")
-	public static void method1174(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3) {
-		GlRenderer.method4162();
-		@Pc(5) float local5 = (float) arg0 + 0.3F;
-		@Pc(10) float local10 = local5 + (float) arg2;
-		@Pc(18) float local18 = (float) GlRenderer.canvasHeight - (float) arg1 - 0.3F;
+	public static void drawHorizontalLine(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int length, @OriginalArg(3) int color) {
+		GlRenderer.setupBlankMaterial();
+		@Pc(5) float local5 = (float) x + 0.3F;
+		@Pc(10) float local10 = local5 + (float) length;
+		@Pc(18) float local18 = (float) GlRenderer.canvasHeight - (float) y - 0.3F;
 		@Pc(20) GL2 local20 = GlRenderer.gl;
 		local20.glBegin(GL2.GL_LINES);
-		local20.glColor3ub((byte) (arg3 >> 16), (byte) (arg3 >> 8), (byte) arg3);
+		local20.glColor3ub((byte) (color >> 16), (byte) (color >> 8), (byte) color);
 		local20.glVertex2f(local5, local18);
 		local20.glVertex2f(local10, local18);
 		local20.glEnd();
 	}
 
 	@OriginalMember(owner = "client!dj", name = "b", descriptor = "(IIII)V")
-	public static void method1176(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3) {
-		GlRenderer.method4162();
-		@Pc(5) float local5 = (float) arg0 + 0.3F;
-		@Pc(13) float local13 = (float) GlRenderer.canvasHeight - (float) arg1 - 0.3F;
-		@Pc(18) float local18 = local13 - (float) arg2;
+	public static void drawVerticalLine(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int length, @OriginalArg(3) int color) {
+		GlRenderer.setupBlankMaterial();
+		@Pc(5) float local5 = (float) x + 0.3F;
+		@Pc(13) float local13 = (float) GlRenderer.canvasHeight - (float) y - 0.3F;
+		@Pc(18) float local18 = local13 - (float) length;
 		@Pc(20) GL2 local20 = GlRenderer.gl;
 		local20.glBegin(GL2.GL_LINES);
-		local20.glColor3ub((byte) (arg3 >> 16), (byte) (arg3 >> 8), (byte) arg3);
+		local20.glColor3ub((byte) (color >> 16), (byte) (color >> 8), (byte) color);
 		local20.glVertex2f(local5, local13);
 		local20.glVertex2f(local5, local18);
 		local20.glEnd();
 	}
 
 	@OriginalMember(owner = "client!dj", name = "c", descriptor = "()V")
-	public static void method1177() {
+	public static void setFullClip() {
 		clipLeft = 0;
 		clipTop = 0;
 		clipRight = GlRenderer.canvasWidth;
@@ -61,29 +61,29 @@ public final class GlRaster {
 	}
 
 	@OriginalMember(owner = "client!dj", name = "a", descriptor = "([IIIII)V")
-	public static void drawPixels(@OriginalArg(0) int[] arg0, @OriginalArg(1) int x, @OriginalArg(2) int y, @OriginalArg(3) int width, @OriginalArg(4) int height) {
-		GlRenderer.method4162();
+	public static void drawPixels(@OriginalArg(0) int[] colors, @OriginalArg(1) int x, @OriginalArg(2) int y, @OriginalArg(3) int width, @OriginalArg(4) int height) {
+		GlRenderer.setupBlankMaterial();
 		@Pc(2) GL2 gl = GlRenderer.gl;
 		gl.glRasterPos2i(x, GlRenderer.canvasHeight - y);
 		gl.glPixelZoom((float) GameShell.canvasScale, (float) -GameShell.canvasScale);
 		gl.glDisable(GL2.GL_BLEND);
 		gl.glDisable(GL2.GL_ALPHA_TEST);
-		gl.glDrawPixels(width, height, GL2.GL_BGRA, GlRenderer.bigEndian ? GL2.GL_UNSIGNED_INT_8_8_8_8_REV : GL2.GL_UNSIGNED_BYTE, IntBuffer.wrap(arg0));
+		gl.glDrawPixels(width, height, GL2.GL_BGRA, GlRenderer.bigEndian ? GL2.GL_UNSIGNED_INT_8_8_8_8_REV : GL2.GL_UNSIGNED_BYTE, IntBuffer.wrap(colors));
 		gl.glPixelZoom(1.0F, 1.0F);
 		gl.glEnable(GL2.GL_ALPHA_TEST);
 		gl.glEnable(GL2.GL_BLEND);
 	}
 
 	@OriginalMember(owner = "client!dj", name = "a", descriptor = "(IIIII)V")
-	public static void drawRect(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
-		GlRenderer.method4162();
-		@Pc(5) float local5 = (float) arg0 + 0.3F;
-		@Pc(12) float local12 = local5 + (float) (arg2 - 1);
-		@Pc(20) float local20 = (float) GlRenderer.canvasHeight - (float) arg1 - 0.3F;
-		@Pc(27) float local27 = local20 - (float) (arg3 - 1);
+	public static void drawRect(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int width, @OriginalArg(3) int height, @OriginalArg(4) int color) {
+		GlRenderer.setupBlankMaterial();
+		@Pc(5) float local5 = (float) x + 0.3F;
+		@Pc(12) float local12 = local5 + (float) (width - 1);
+		@Pc(20) float local20 = (float) GlRenderer.canvasHeight - (float) y - 0.3F;
+		@Pc(27) float local27 = local20 - (float) (height - 1);
 		@Pc(29) GL2 local29 = GlRenderer.gl;
 		local29.glBegin(GL2.GL_LINE_LOOP);
-		local29.glColor3ub((byte) (arg4 >> 16), (byte) (arg4 >> 8), (byte) arg4);
+		local29.glColor3ub((byte) (color >> 16), (byte) (color >> 8), (byte) color);
 		local29.glVertex2f(local5, local20);
 		local29.glVertex2f(local5, local27);
 		local29.glVertex2f(local12, local27);
@@ -92,15 +92,15 @@ public final class GlRaster {
 	}
 
 	@OriginalMember(owner = "client!dj", name = "a", descriptor = "(IIIIII)V")
-	public static void method1180(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5) {
-		GlRenderer.method4162();
-		@Pc(5) float local5 = (float) arg0 + 0.3F;
-		@Pc(12) float local12 = local5 + (float) (arg2 - 1);
-		@Pc(20) float local20 = (float) GlRenderer.canvasHeight - (float) arg1 - 0.3F;
-		@Pc(27) float local27 = local20 - (float) (arg3 - 1);
+	public static void drawRectAlpha(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int width, @OriginalArg(3) int height, @OriginalArg(4) int color, @OriginalArg(5) int alpha) {
+		GlRenderer.setupBlankMaterial();
+		@Pc(5) float local5 = (float) x + 0.3F;
+		@Pc(12) float local12 = local5 + (float) (width - 1);
+		@Pc(20) float local20 = (float) GlRenderer.canvasHeight - (float) y - 0.3F;
+		@Pc(27) float local27 = local20 - (float) (height - 1);
 		@Pc(29) GL2 local29 = GlRenderer.gl;
 		local29.glBegin(GL2.GL_LINE_LOOP);
-		local29.glColor4ub((byte) (arg4 >> 16), (byte) (arg4 >> 8), (byte) arg4, arg5 > 255 ? -1 : (byte) arg5);
+		local29.glColor4ub((byte) (color >> 16), (byte) (color >> 8), (byte) color, alpha > 255 ? -1 : (byte) alpha);
 		local29.glVertex2f(local5, local20);
 		local29.glVertex2f(local5, local27);
 		local29.glVertex2f(local12, local27);
@@ -109,9 +109,9 @@ public final class GlRaster {
 	}
 
 	@OriginalMember(owner = "client!dj", name = "b", descriptor = "(IIIIII)V")
-	public static void method1181(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5) {
-		@Pc(3) int local3 = arg2 - arg0;
-		@Pc(7) int local7 = arg3 - arg1;
+	public static void renderLine(@OriginalArg(0) int x0, @OriginalArg(1) int y0, @OriginalArg(2) int x1, @OriginalArg(3) int y1, @OriginalArg(4) int color, @OriginalArg(5) int lineWidth) {
+		@Pc(3) int local3 = x1 - x0;
+		@Pc(7) int local7 = y1 - y0;
 		@Pc(14) int local14 = local3 >= 0 ? local3 : -local3;
 		@Pc(21) int local21 = local7 >= 0 ? local7 : -local7;
 		@Pc(23) int local23 = local14;
@@ -128,21 +128,21 @@ public final class GlRaster {
 		} else {
 			local43 = -local43;
 		}
-		@Pc(59) int local59 = arg5 * local43 >> 17;
-		@Pc(67) int local67 = arg5 * local43 + 1 >> 17;
-		@Pc(73) int local73 = arg5 * local37 >> 17;
-		@Pc(81) int local81 = arg5 * local37 + 1 >> 17;
-		@Pc(85) int local85 = arg0 + local59;
-		@Pc(89) int local89 = arg0 - local67;
-		@Pc(95) int local95 = arg0 + local3 - local67;
-		@Pc(101) int local101 = arg0 + local3 + local59;
-		@Pc(105) int local105 = arg1 + local73;
-		@Pc(109) int local109 = arg1 - local81;
-		@Pc(115) int local115 = arg1 + local7 - local81;
-		@Pc(121) int local121 = arg1 + local7 + local73;
-		GlRenderer.method4162();
+		@Pc(59) int local59 = lineWidth * local43 >> 17;
+		@Pc(67) int local67 = lineWidth * local43 + 1 >> 17;
+		@Pc(73) int local73 = lineWidth * local37 >> 17;
+		@Pc(81) int local81 = lineWidth * local37 + 1 >> 17;
+		@Pc(85) int local85 = x0 + local59;
+		@Pc(89) int local89 = x0 - local67;
+		@Pc(95) int local95 = x0 + local3 - local67;
+		@Pc(101) int local101 = x0 + local3 + local59;
+		@Pc(105) int local105 = y0 + local73;
+		@Pc(109) int local109 = y0 - local81;
+		@Pc(115) int local115 = y0 + local7 - local81;
+		@Pc(121) int local121 = y0 + local7 + local73;
+		GlRenderer.setupBlankMaterial();
 		@Pc(124) GL2 local124 = GlRenderer.gl;
-		local124.glColor3ub((byte) (arg4 >> 16), (byte) (arg4 >> 8), (byte) arg4);
+		local124.glColor3ub((byte) (color >> 16), (byte) (color >> 8), (byte) color);
 		local124.glBegin(GL2.GL_TRIANGLE_FAN);
 		if (local43 <= local37) {
 			local124.glVertex2f((float) local101, (float) (GlRenderer.canvasHeight - local121));
@@ -159,15 +159,15 @@ public final class GlRaster {
 	}
 
 	@OriginalMember(owner = "client!dj", name = "c", descriptor = "(IIIIII)V")
-	public static void fillRectAlpha(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5) {
-		GlRenderer.method4162();
-		@Pc(3) float local3 = (float) arg0;
-		@Pc(8) float local8 = local3 + (float) arg2;
-		@Pc(13) float local13 = (float) (GlRenderer.canvasHeight - arg1);
-		@Pc(18) float local18 = local13 - (float) arg3;
+	public static void fillRectAlpha(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int width, @OriginalArg(3) int height, @OriginalArg(4) int color, @OriginalArg(5) int alpha) {
+		GlRenderer.setupBlankMaterial();
+		@Pc(3) float local3 = (float) x;
+		@Pc(8) float local8 = local3 + (float) width;
+		@Pc(13) float local13 = (float) (GlRenderer.canvasHeight - y);
+		@Pc(18) float local18 = local13 - (float) height;
 		@Pc(20) GL2 local20 = GlRenderer.gl;
 		local20.glBegin(GL2.GL_TRIANGLE_FAN);
-		local20.glColor4ub((byte) (arg4 >> 16), (byte) (arg4 >> 8), (byte) arg4, arg5 > 255 ? -1 : (byte) arg5);
+		local20.glColor4ub((byte) (color >> 16), (byte) (color >> 8), (byte) color, alpha > 255 ? -1 : (byte) alpha);
 		local20.glVertex2f(local3, local13);
 		local20.glVertex2f(local3, local18);
 		local20.glVertex2f(local8, local18);
@@ -176,18 +176,18 @@ public final class GlRaster {
 	}
 
 	@OriginalMember(owner = "client!dj", name = "c", descriptor = "(IIII)V")
-	public static void method1183(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3) {
-		if (clipLeft < arg0) {
-			clipLeft = arg0;
+	public static void shrinkClip(@OriginalArg(0) int left, @OriginalArg(1) int top, @OriginalArg(2) int right, @OriginalArg(3) int bottom) {
+		if (clipLeft < left) {
+			clipLeft = left;
 		}
-		if (clipTop < arg1) {
-			clipTop = arg1;
+		if (clipTop < top) {
+			clipTop = top;
 		}
-		if (clipRight > arg2) {
-			clipRight = arg2;
+		if (clipRight > right) {
+			clipRight = right;
 		}
-		if (clipBottom > arg3) {
-			clipBottom = arg3;
+		if (clipBottom > bottom) {
+			clipBottom = bottom;
 		}
 		@Pc(21) GL2 gl = GlRenderer.gl;
 		gl.glEnable(GL2.GL_SCISSOR_TEST);
@@ -205,15 +205,15 @@ public final class GlRaster {
 	}
 
 	@OriginalMember(owner = "client!dj", name = "b", descriptor = "(IIIII)V")
-	public static void method1185(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
-		GlRenderer.method4162();
-		@Pc(5) float local5 = (float) arg0 + 0.3F;
-		@Pc(10) float local10 = (float) arg2 + 0.3F;
-		@Pc(18) float local18 = (float) GlRenderer.canvasHeight - (float) arg1 - 0.3F;
-		@Pc(26) float local26 = (float) GlRenderer.canvasHeight - (float) arg3 - 0.3F;
+	public static void renderLine(@OriginalArg(0) int x0, @OriginalArg(1) int y0, @OriginalArg(2) int x1, @OriginalArg(3) int y2, @OriginalArg(4) int color) {
+		GlRenderer.setupBlankMaterial();
+		@Pc(5) float local5 = (float) x0 + 0.3F;
+		@Pc(10) float local10 = (float) x1 + 0.3F;
+		@Pc(18) float local18 = (float) GlRenderer.canvasHeight - (float) y0 - 0.3F;
+		@Pc(26) float local26 = (float) GlRenderer.canvasHeight - (float) y2 - 0.3F;
 		@Pc(28) GL2 local28 = GlRenderer.gl;
 		local28.glBegin(GL2.GL_LINE_LOOP);
-		local28.glColor3ub((byte) (arg4 >> 16), (byte) (arg4 >> 8), (byte) arg4);
+		local28.glColor3ub((byte) (color >> 16), (byte) (color >> 8), (byte) color);
 		local28.glVertex2f(local5, local18);
 		local28.glVertex2f(local10, local26);
 		local28.glEnd();
@@ -221,7 +221,7 @@ public final class GlRaster {
 
 	@OriginalMember(owner = "client!dj", name = "c", descriptor = "(IIIII)V")
 	public static void fillRect(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int width, @OriginalArg(3) int height, @OriginalArg(4) int color) {
-		GlRenderer.method4162();
+		GlRenderer.setupBlankMaterial();
 		@Pc(3) float local3 = (float) x;
 		@Pc(8) float local8 = local3 + (float) width;
 		@Pc(13) float local13 = (float) (GlRenderer.canvasHeight - y);
@@ -237,23 +237,23 @@ public final class GlRaster {
 	}
 
 	@OriginalMember(owner = "client!dj", name = "d", descriptor = "(IIII)V")
-	public static void setClip(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3) {
-		if (arg0 < 0) {
-			arg0 = 0;
+	public static void setClip(@OriginalArg(0) int left, @OriginalArg(1) int top, @OriginalArg(2) int right, @OriginalArg(3) int bottom) {
+		if (left < 0) {
+			left = 0;
 		}
-		if (arg1 < 0) {
-			arg1 = 0;
+		if (top < 0) {
+			top = 0;
 		}
-		if (arg2 > GlRenderer.canvasWidth) {
-			arg2 = GlRenderer.canvasWidth;
+		if (right > GlRenderer.canvasWidth) {
+			right = GlRenderer.canvasWidth;
 		}
-		if (arg3 > GlRenderer.canvasHeight) {
-			arg3 = GlRenderer.canvasHeight;
+		if (bottom > GlRenderer.canvasHeight) {
+			bottom = GlRenderer.canvasHeight;
 		}
-		clipLeft = arg0;
-		clipTop = arg1;
-		clipRight = arg2;
-		clipBottom = arg3;
+		clipLeft = left;
+		clipTop = top;
+		clipRight = right;
+		clipBottom = bottom;
 		@Pc(27) GL2 local27 = GlRenderer.gl;
 		local27.glEnable(GL2.GL_SCISSOR_TEST);
 		if (clipLeft <= clipRight && clipTop <= clipBottom) {

--- a/client/src/main/java/rt4/GlRenderer.java
+++ b/client/src/main/java/rt4/GlRenderer.java
@@ -140,7 +140,7 @@ public final class GlRenderer {
 	@OriginalMember(owner = "client!tf", name = "a", descriptor = "()V")
 	public static void method4149() {
 		MaterialManager.setMaterial(0, 0);
-		method4163();
+		setupOrthographicProjection();
 		setTextureCombineRgbMode(1);
 		setTextureCombineAlphaMode(1);
 		setLightingEnabled(false);
@@ -162,7 +162,7 @@ public final class GlRenderer {
 	@OriginalMember(owner = "client!tf", name = "c", descriptor = "()V")
 	public static void method4151() {
 		MaterialManager.setMaterial(0, 0); // MaterialManager
-		method4163();
+		setupOrthographicProjection();
 		setTextureCombineRgbMode(0);
 		setTextureCombineAlphaMode(0);
 		setLightingEnabled(false);
@@ -217,7 +217,7 @@ public final class GlRenderer {
 	@OriginalMember(owner = "client!tf", name = "e", descriptor = "()V")
 	public static void method4155() {
 		MaterialManager.setMaterial(0, 0);
-		method4163();
+		setupOrthographicProjection();
 		setTextureCombineRgbMode(0);
 		setTextureCombineAlphaMode(0);
 		setLightingEnabled(false);
@@ -342,9 +342,9 @@ public final class GlRenderer {
 	}
 
 	@OriginalMember(owner = "client!tf", name = "i", descriptor = "()V")
-	public static void method4162() {
+	public static void setupBlankMaterial() {
 		MaterialManager.setMaterial(0, 0);
-		method4163();
+		setupOrthographicProjection();
 		setTextureId(-1);
 		setLightingEnabled(false);
 		setDepthTestEnabled(false);
@@ -353,7 +353,7 @@ public final class GlRenderer {
 	}
 
 	@OriginalMember(owner = "client!tf", name = "j", descriptor = "()V")
-	private static void method4163() {
+	private static void setupOrthographicProjection() {
 		if (aBoolean266) {
 			return;
 		}

--- a/client/src/main/java/rt4/GlRenderer.java
+++ b/client/src/main/java/rt4/GlRenderer.java
@@ -511,7 +511,7 @@ public final class GlRenderer {
 		gl = null;
 		context = null;
 		drawable = null;
-		LightingManager.method2398(); // LightingManager
+		LightingManager.clear(); // LightingManager
 		enabled = false;
 	}
 
@@ -808,7 +808,7 @@ public final class GlRenderer {
 		anInt5328 = local2[0];
 		gl.glBindTexture(GL2.GL_TEXTURE_2D, anInt5328);
 		gl.glTexImage2D(GL2.GL_TEXTURE_2D, 0, 4, 1, 1, 0, GL2.GL_RGBA, GL2.GL_UNSIGNED_BYTE, IntBuffer.wrap(new int[]{-1}));
-		LightingManager.method2401();
+		LightingManager.init();
 		MaterialManager.init();
 	}
 

--- a/client/src/main/java/rt4/InterfaceList.java
+++ b/client/src/main/java/rt4/InterfaceList.java
@@ -1137,9 +1137,9 @@ public class InterfaceList {
 			Cs1ScriptRunner.method182();
 		}
 		if (GlRenderer.enabled) {
-			GlRaster.method1177();
+			GlRaster.setFullClip();
 		} else {
-			SoftwareRaster.method2503();
+			SoftwareRaster.setFullClip();
 		}
 		Protocol.sceneDelta = 0;
 	}

--- a/client/src/main/java/rt4/Light.java
+++ b/client/src/main/java/rt4/Light.java
@@ -10,14 +10,20 @@ public final class Light {
 
 	@OriginalMember(owner = "client!f", name = "P", descriptor = "[I")
 	public static int[] NOISE;
+
+	// THIS IS A WILD STAB IN THE DARK (hehe)
 	@OriginalMember(owner = "client!gi", name = "a", descriptor = "Z")
-	public final boolean aBoolean124;
+	public final boolean shineOnLowerLevels;
+
+	// THIS IS A WILD STAB IN THE DARK (hehe)
+	@OriginalMember(owner = "client!gi", name = "A", descriptor = "Z")
+	public final boolean shineOnHigherLevels;
 
 	@OriginalMember(owner = "client!gi", name = "d", descriptor = "I")
 	private int alphaMax;
 
 	@OriginalMember(owner = "client!gi", name = "e", descriptor = "I")
-	private int anInt2233;
+	private int flickerType;
 
 	@OriginalMember(owner = "client!gi", name = "i", descriptor = "I")
 	public int y;
@@ -35,7 +41,7 @@ public final class Light {
 	public int level;
 
 	@OriginalMember(owner = "client!gi", name = "t", descriptor = "I")
-	public final int anInt2243;
+	public final int lightType;
 
 	@OriginalMember(owner = "client!gi", name = "u", descriptor = "[S")
 	public final short[] aShortArray30;
@@ -51,9 +57,6 @@ public final class Light {
 
 	@OriginalMember(owner = "client!gi", name = "z", descriptor = "F")
 	public float aFloat9;
-
-	@OriginalMember(owner = "client!gi", name = "A", descriptor = "Z")
-	public final boolean aBoolean126;
 
 	@OriginalMember(owner = "client!gi", name = "B", descriptor = "Lclient!fj;")
 	public Light_Class45 aClass45_1;
@@ -71,40 +74,40 @@ public final class Light {
 	public final float[] diffuse = new float[4];
 
 	@OriginalMember(owner = "client!gi", name = "<init>", descriptor = "(Lclient!wa;)V")
-	public Light(@OriginalArg(0) Buffer arg0) {
+	public Light(@OriginalArg(0) Buffer buffer) {
 		if (NOISE == null) {
 			init();
 		}
-		this.level = arg0.g1();
-		this.aBoolean124 = (this.level & 0x10) != 0;
-		this.aBoolean126 = (this.level & 0x8) != 0;
+		this.level = buffer.g1();
+		this.shineOnLowerLevels = (this.level & 0x10) != 0;
+		this.shineOnHigherLevels = (this.level & 0x8) != 0;
 		this.level &= 0x7;
-		this.x = arg0.g2();
-		this.z = arg0.g2();
-		this.y = arg0.g2();
-		this.radius = arg0.g1();
+		this.x = buffer.g2();
+		this.z = buffer.g2();
+		this.y = buffer.g2();
+		this.radius = buffer.g1();
 		this.method1763();
 		this.aShortArray30 = new short[this.radius * 2 + 1];
-		@Pc(87) int local87;
-		for (local87 = 0; local87 < this.aShortArray30.length; local87++) {
-			this.aShortArray30[local87] = (short) arg0.g2();
+		@Pc(87) int i;
+		for (i = 0; i < this.aShortArray30.length; i++) {
+			this.aShortArray30[i] = (short) buffer.g2();
 		}
-		this.color = Rasteriser.palette[arg0.g2()];
-		local87 = arg0.g1();
-		this.anInt2249 = (local87 & 0xE0) << 3;
-		this.anInt2243 = local87 & 0x1F;
-		if (this.anInt2243 != 31) {
-			this.method1766();
+		this.color = Rasteriser.palette[buffer.g2()];
+		i = buffer.g1();
+		this.anInt2249 = (i & 0xE0) << 3;
+		this.lightType = i & 0x1F;
+		if (this.lightType != 31) {
+			this.applyLightType();
 		}
 	}
 
 	@OriginalMember(owner = "client!gk", name = "b", descriptor = "(B)V")
 	public static void init() {
-		NOISE = craeteNoise(0.4F);
+		NOISE = createNoise(0.4F);
 	}
 
 	@OriginalMember(owner = "client!qk", name = "a", descriptor = "(ZIIIIFII)[I")
-	public static int[] craeteNoise(@OriginalArg(5) float arg0) {
+	public static int[] createNoise(@OriginalArg(5) float arg0) {
 		@Pc(11) int[] local11 = new int[2048];
 		@Pc(15) TextureOp34 local15 = new TextureOp34();
 		local15.anInt646 = 8;
@@ -120,10 +123,10 @@ public final class Light {
 	}
 
 	@OriginalMember(owner = "client!gi", name = "a", descriptor = "(BIIII)V")
-	public final void method1762(@OriginalArg(1) int arg0, @OriginalArg(2) int arg1, @OriginalArg(3) int arg2, @OriginalArg(4) int arg3) {
-		this.anInt2233 = arg0;
-		this.alphaMin = arg2;
-		this.alphaMax = arg3;
+	public final void setUpLightType(@OriginalArg(1) int flickerType, @OriginalArg(2) int arg1, @OriginalArg(3) int alphaMin, @OriginalArg(4) int alphaMax) {
+		this.flickerType = flickerType;
+		this.alphaMin = alphaMin;
+		this.alphaMax = alphaMax;
 		this.anInt2246 = arg1;
 	}
 
@@ -134,19 +137,19 @@ public final class Light {
 	}
 
 	@OriginalMember(owner = "client!gi", name = "a", descriptor = "(ZII)V")
-	public final void method1765(@OriginalArg(0) boolean disableFlicker, @OriginalArg(1) int arg1) {
-		@Pc(26) int t = this.anInt2249 + arg1 * this.anInt2246 / 50 & 0x7FF;
-		@Pc(29) int local29 = this.anInt2233;
+	public final void method1765(@OriginalArg(0) boolean disableFlicker, @OriginalArg(1) int time) {
+		@Pc(26) int t = (this.anInt2249 + ((time * this.anInt2246) / 50)) & 0x7FF;
+		@Pc(29) int flickerType = this.flickerType;
 		@Pc(62) int alpha;
-		if (local29 == 1) {
+		if (flickerType == 1) {
 			alpha = (MathUtils.sin[t] >> 6) + 1024;
-		} else if (local29 == 3) {
+		} else if (flickerType == 3) {
 			alpha = NOISE[t] >> 1;
-		} else if (local29 == 4) {
+		} else if (flickerType == 4) {
 			alpha = t >> 10 << 11;
-		} else if (local29 == 2) {
+		} else if (flickerType == 2) {
 			alpha = t;
-		} else if (local29 == 5) {
+		} else if (flickerType == 5) {
 			alpha = (t < 1024 ? t : 2048 - t) << 1;
 		} else {
 			alpha = 2048;
@@ -162,88 +165,105 @@ public final class Light {
 	}
 
 	@OriginalMember(owner = "client!gi", name = "c", descriptor = "(I)V")
-	private void method1766() {
-		@Pc(4) int local4 = this.anInt2243;
-		if (local4 == 2) {
-			this.alphaMin = 2048;
-			this.alphaMax = 0;
-			this.anInt2233 = 1;
-			this.anInt2246 = 2048;
-		} else if (local4 == 3) {
-			this.alphaMax = 0;
-			this.anInt2246 = 4096;
-			this.anInt2233 = 1;
-			this.alphaMin = 2048;
-		} else if (local4 == 4) {
-			this.alphaMax = 0;
-			this.alphaMin = 2048;
-			this.anInt2233 = 4;
-			this.anInt2246 = 2048;
-		} else if (local4 == 5) {
-			this.anInt2233 = 4;
-			this.alphaMin = 2048;
-			this.anInt2246 = 8192;
-			this.alphaMax = 0;
-		} else if (local4 == 12) {
-			this.alphaMin = 2048;
-			this.anInt2233 = 2;
-			this.anInt2246 = 2048;
-			this.alphaMax = 0;
-		} else if (local4 == 13) {
-			this.anInt2246 = 8192;
-			this.alphaMin = 2048;
-			this.anInt2233 = 2;
-			this.alphaMax = 0;
-		} else if (local4 == 10) {
-			this.alphaMin = 512;
-			this.anInt2233 = 3;
-			this.alphaMax = 1536;
-			this.anInt2246 = 2048;
-		} else if (local4 == 11) {
-			this.anInt2233 = 3;
-			this.anInt2246 = 4096;
-			this.alphaMin = 512;
-			this.alphaMax = 1536;
-		} else if (local4 == 6) {
-			this.alphaMin = 768;
-			this.alphaMax = 1280;
-			this.anInt2233 = 3;
-			this.anInt2246 = 2048;
-		} else if (local4 == 7) {
-			this.alphaMin = 768;
-			this.alphaMax = 1280;
-			this.anInt2246 = 4096;
-			this.anInt2233 = 3;
-		} else if (local4 == 8) {
-			this.anInt2246 = 2048;
-			this.anInt2233 = 3;
-			this.alphaMin = 1024;
-			this.alphaMax = 1024;
-		} else if (local4 == 9) {
-			this.anInt2246 = 4096;
-			this.alphaMax = 1024;
-			this.alphaMin = 1024;
-			this.anInt2233 = 3;
-		} else if (local4 == 14) {
-			this.anInt2246 = 2048;
-			this.alphaMax = 1280;
-			this.anInt2233 = 1;
-			this.alphaMin = 768;
-		} else if (local4 == 15) {
-			this.alphaMin = 512;
-			this.anInt2246 = 4096;
-			this.alphaMax = 1536;
-			this.anInt2233 = 1;
-		} else if (local4 == 16) {
-			this.anInt2246 = 8192;
-			this.alphaMax = 1792;
-			this.anInt2233 = 1;
-			this.alphaMin = 256;
-		} else {
-			this.anInt2246 = 2048;
-			this.alphaMax = 0;
-			this.alphaMin = 2048;
-			this.anInt2233 = 0;
+	private void applyLightType() {
+		@Pc(4) int type = this.lightType;
+		switch (type) {
+			case 2:
+				this.alphaMin = 2048;
+				this.alphaMax = 0;
+				this.flickerType = 1;
+				this.anInt2246 = 2048;
+				break;
+			case 3:
+				this.alphaMax = 0;
+				this.anInt2246 = 4096;
+				this.flickerType = 1;
+				this.alphaMin = 2048;
+				break;
+			case 4:
+				this.alphaMax = 0;
+				this.alphaMin = 2048;
+				this.flickerType = 4;
+				this.anInt2246 = 2048;
+				break;
+			case 5:
+				this.flickerType = 4;
+				this.alphaMin = 2048;
+				this.anInt2246 = 8192;
+				this.alphaMax = 0;
+				break;
+			case 12:
+				this.alphaMin = 2048;
+				this.flickerType = 2;
+				this.anInt2246 = 2048;
+				this.alphaMax = 0;
+				break;
+			case 13:
+				this.anInt2246 = 8192;
+				this.alphaMin = 2048;
+				this.flickerType = 2;
+				this.alphaMax = 0;
+				break;
+			case 10:
+				this.alphaMin = 512;
+				this.flickerType = 3;
+				this.alphaMax = 1536;
+				this.anInt2246 = 2048;
+				break;
+			case 11:
+				this.flickerType = 3;
+				this.anInt2246 = 4096;
+				this.alphaMin = 512;
+				this.alphaMax = 1536;
+				break;
+			case 6:
+				this.alphaMin = 768;
+				this.alphaMax = 1280;
+				this.flickerType = 3;
+				this.anInt2246 = 2048;
+				break;
+			case 7:
+				this.alphaMin = 768;
+				this.alphaMax = 1280;
+				this.anInt2246 = 4096;
+				this.flickerType = 3;
+				break;
+			case 8:
+				this.anInt2246 = 2048;
+				this.flickerType = 3;
+				this.alphaMin = 1024;
+				this.alphaMax = 1024;
+				break;
+			case 9:
+				this.anInt2246 = 4096;
+				this.alphaMax = 1024;
+				this.alphaMin = 1024;
+				this.flickerType = 3;
+				break;
+			case 14:
+				this.anInt2246 = 2048;
+				this.alphaMax = 1280;
+				this.flickerType = 1;
+				this.alphaMin = 768;
+				break;
+			case 15:
+				this.alphaMin = 512;
+				this.anInt2246 = 4096;
+				this.alphaMax = 1536;
+				this.flickerType = 1;
+				break;
+			case 16:
+				this.anInt2246 = 8192;
+				this.alphaMax = 1792;
+				this.flickerType = 1;
+				this.alphaMin = 256;
+				break;
+			default:
+				this.anInt2246 = 2048;
+				this.alphaMax = 0;
+				this.alphaMin = 2048;
+				this.flickerType = 0;
+				break;
 		}
 	}
 }

--- a/client/src/main/java/rt4/Light.java
+++ b/client/src/main/java/rt4/Light.java
@@ -11,11 +11,11 @@ public final class Light {
 	@OriginalMember(owner = "client!f", name = "P", descriptor = "[I")
 	public static int[] NOISE;
 
-	// THIS IS A WILD STAB IN THE DARK (hehe)
+	// TODO: this is an educated guess, needs confirming
 	@OriginalMember(owner = "client!gi", name = "a", descriptor = "Z")
 	public final boolean shineOnLowerLevels;
 
-	// THIS IS A WILD STAB IN THE DARK (hehe)
+	// confirm
 	@OriginalMember(owner = "client!gi", name = "A", descriptor = "Z")
 	public final boolean shineOnHigherLevels;
 

--- a/client/src/main/java/rt4/LightType.java
+++ b/client/src/main/java/rt4/LightType.java
@@ -9,38 +9,39 @@ import org.openrs2.deob.annotation.Pc;
 public final class LightType {
 
 	@OriginalMember(owner = "client!ic", name = "g", descriptor = "I")
-	public int anInt2867 = 2048;
+	public int alphaMin = 2048;
 
 	@OriginalMember(owner = "client!ic", name = "c", descriptor = "I")
-	public int anInt2865 = 0;
+	public int flickerType = 0;
 
 	@OriginalMember(owner = "client!ic", name = "o", descriptor = "I")
-	public int anInt2872 = 0;
+	public int alphaMax = 0;
 
 	@OriginalMember(owner = "client!ic", name = "p", descriptor = "I")
 	public int anInt2873 = 2048;
 
 	@OriginalMember(owner = "client!ic", name = "a", descriptor = "(ILclient!wa;I)V")
-	public final void decode(@OriginalArg(1) Buffer arg0, @OriginalArg(2) int arg1) {
+	public final void decode(@OriginalArg(1) Buffer buffer, @OriginalArg(2) int arg1) {
 		while (true) {
-			@Pc(5) int local5 = arg0.g1();
-			if (local5 == 0) {
+			// Unsure this is type
+			@Pc(5) int lightType = buffer.g1();
+			if (lightType == 0) {
 				return;
 			}
-			this.method2258(local5, arg0, arg1);
+			this.decode(lightType, buffer, arg1);
 		}
 	}
 
 	@OriginalMember(owner = "client!ic", name = "a", descriptor = "(ILclient!wa;IZ)V")
-	private void method2258(@OriginalArg(0) int arg0, @OriginalArg(1) Buffer arg1, @OriginalArg(2) int arg2) {
-		if (arg0 == 1) {
-			this.anInt2865 = arg1.g1();
-		} else if (arg0 == 2) {
-			this.anInt2873 = arg1.g2();
-		} else if (arg0 == 3) {
-			this.anInt2867 = arg1.g2();
-		} else if (arg0 == 4) {
-			this.anInt2872 = arg1.g2b();
+	private void decode(@OriginalArg(0) int lightType, @OriginalArg(1) Buffer buffer, @OriginalArg(2) int arg2) {
+		if (lightType == 1) {
+			this.flickerType = buffer.g1();
+		} else if (lightType == 2) {
+			this.anInt2873 = buffer.g2();
+		} else if (lightType == 3) {
+			this.alphaMin = buffer.g2();
+		} else if (lightType == 4) {
+			this.alphaMax = buffer.g2b();
 		}
 	}
 }

--- a/client/src/main/java/rt4/LightingManager.java
+++ b/client/src/main/java/rt4/LightingManager.java
@@ -37,7 +37,7 @@ public class LightingManager {
 	@OriginalMember(owner = "client!jf", name = "i", descriptor = "I")
 	private static int anInt3031;
 	@OriginalMember(owner = "client!jf", name = "j", descriptor = "I")
-	private static int anInt3032;
+	private static int levels;
 	@OriginalMember(owner = "client!jf", name = "k", descriptor = "I")
 	private static int anInt3033;
 	@OriginalMember(owner = "client!jf", name = "m", descriptor = "[Z")
@@ -169,11 +169,11 @@ public class LightingManager {
 	}
 
 	@OriginalMember(owner = "client!jf", name = "a", descriptor = "(III)V")
-	public static void method2392() {
-		anInt3032 = 4;
+	public static void setSize() {
+		levels = 4;
 		width = 104;
 		length = 104;
-		anIntArrayArrayArray11 = new int[anInt3032][width][length];
+		anIntArrayArrayArray11 = new int[levels][width][length];
 	}
 
 	@OriginalMember(owner = "client!jf", name = "a", descriptor = "(IIIIII)V")
@@ -181,11 +181,11 @@ public class LightingManager {
 		if (!Preferences.highDetailLighting || anInt3031 == level && anInt3033 == nodeX && anInt3029 == nodeY && anInt3035 == nodeX && anInt3030 == nodeY) {
 			return;
 		}
-		@Pc(20) int local20;
-		for (local20 = 0; local20 < 4; local20++) {
-			aBooleanArray66[local20] = false;
+		@Pc(20) int i;
+		for (i = 0; i < 4; i++) {
+			aBooleanArray66[i] = false;
 		}
-		local20 = 0;
+		i = 0;
 		@Pc(39) int local39 = anIntArrayArrayArray11[level][nodeX][nodeY];
 		while (true) {
 			@Pc(47) int local47;
@@ -200,9 +200,9 @@ public class LightingManager {
 						continue label72;
 					}
 				}
-				anIntArray283[local20++] = local47;
+				anIntArray283[i++] = local47;
 			}
-			for (local47 = 0; local47 < local20; local47++) {
+			for (local47 = 0; local47 < i; local47++) {
 				for (local53 = 0; local53 < 4; local53++) {
 					if (!aBooleanArray66[local53]) {
 						anIntArray284[local53] = anIntArray283[local47];
@@ -228,9 +228,9 @@ public class LightingManager {
 	}
 
 	@OriginalMember(owner = "client!jf", name = "a", descriptor = "(IZ)V")
-	public static void method2394(@OriginalArg(0) int arg0, @OriginalArg(1) boolean arg1) {
-		for (@Pc(1) int local1 = 0; local1 < lightCount; local1++) {
-			lights[local1].method1765(arg1, arg0);
+	public static void method2394(@OriginalArg(0) int time, @OriginalArg(1) boolean arg1) {
+		for (@Pc(1) int i = 0; i < lightCount; i++) {
+			lights[i].method1765(arg1, time);
 		}
 		anInt3031 = -1;
 		anInt3033 = -1;
@@ -240,31 +240,31 @@ public class LightingManager {
 	}
 
 	@OriginalMember(owner = "client!jf", name = "b", descriptor = "()V")
-	public static void method2395() {
-		for (@Pc(1) int local1 = 0; local1 < lightCount; local1++) {
-			@Pc(8) Light local8 = lights[local1];
-			@Pc(11) int local11 = local8.level;
-			if (local8.aBoolean124) {
-				local11 = 0;
+	public static void calculateLightRadiuses() {
+		for (@Pc(1) int i = 0; i < lightCount; i++) {
+			@Pc(8) Light light = lights[i];
+			@Pc(11) int minLevel = light.level;
+			if (light.shineOnLowerLevels) {
+				minLevel = 0;
 			}
-			@Pc(19) int local19 = local8.level;
-			if (local8.aBoolean126) {
-				local19 = 3;
+			@Pc(19) int maxLevel = light.level;
+			if (light.shineOnHigherLevels) {
+				maxLevel = 3;
 			}
-			for (@Pc(26) int local26 = local11; local26 <= local19; local26++) {
+			for (@Pc(26) int level = minLevel; level <= maxLevel; level++) {
 				@Pc(31) int local31 = 0;
-				@Pc(39) int local39 = (local8.z >> 7) - local8.radius;
+				@Pc(39) int local39 = (light.z >> 7) - light.radius;
 				if (local39 < 0) {
 					local31 = -local39;
 					local39 = 0;
 				}
-				@Pc(55) int local55 = (local8.z >> 7) + local8.radius;
+				@Pc(55) int local55 = (light.z >> 7) + light.radius;
 				if (local55 > length - 1) {
 					local55 = length - 1;
 				}
 				for (@Pc(66) int local66 = local39; local66 <= local55; local66++) {
-					@Pc(75) short local75 = local8.aShortArray30[local31++];
-					@Pc(87) int local87 = (local8.x >> 7) + (local75 >> 8) - local8.radius;
+					@Pc(75) short local75 = light.aShortArray30[local31++];
+					@Pc(87) int local87 = (light.x >> 7) + (local75 >> 8) - light.radius;
 					@Pc(95) int local95 = local87 + (local75 & 0xFF) - 1;
 					if (local87 < 0) {
 						local87 = 0;
@@ -273,15 +273,15 @@ public class LightingManager {
 						local95 = width - 1;
 					}
 					for (@Pc(110) int local110 = local87; local110 <= local95; local110++) {
-						@Pc(121) int local121 = anIntArrayArrayArray11[local26][local110][local66];
+						@Pc(121) int local121 = anIntArrayArrayArray11[level][local110][local66];
 						if ((local121 & 0xFF) == 0) {
-							anIntArrayArrayArray11[local26][local110][local66] = local121 | local1 + 1;
+							anIntArrayArrayArray11[level][local110][local66] = local121 | i + 1;
 						} else if ((local121 & 0xFF00) == 0) {
-							anIntArrayArrayArray11[local26][local110][local66] = local121 | local1 + 1 << 8;
+							anIntArrayArrayArray11[level][local110][local66] = local121 | i + 1 << 8;
 						} else if ((local121 & 0xFF0000) == 0) {
-							anIntArrayArrayArray11[local26][local110][local66] = local121 | local1 + 1 << 16;
+							anIntArrayArrayArray11[level][local110][local66] = local121 | i + 1 << 16;
 						} else if ((local121 & 0xFF000000) == 0) {
-							anIntArrayArrayArray11[local26][local110][local66] = local121 | local1 + 1 << 24;
+							anIntArrayArrayArray11[level][local110][local66] = local121 | i + 1 << 24;
 						}
 					}
 				}
@@ -300,14 +300,14 @@ public class LightingManager {
 	}
 
 	@OriginalMember(owner = "client!jf", name = "a", descriptor = "(IIIII)V")
-	public static void method2397(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
+	public static void method2397(@OriginalArg(0) int level, @OriginalArg(1) int tileX, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int tileZ) {
 		if (!Preferences.highDetailLighting) {
 			return;
 		}
 		label43:
 		for (@Pc(4) int local4 = 0; local4 < 4; local4++) {
 			if (anIntArray284[local4] != -1) {
-				@Pc(20) int local20 = anIntArrayArrayArray11[arg0][arg1][arg2];
+				@Pc(20) int local20 = anIntArrayArrayArray11[level][tileX][arg2];
 				@Pc(28) int local28;
 				while (local20 != 0) {
 					local28 = (local20 & 0xFF) - 1;
@@ -316,7 +316,7 @@ public class LightingManager {
 						continue label43;
 					}
 				}
-				local20 = anIntArrayArrayArray11[arg0][arg3][arg4];
+				local20 = anIntArrayArrayArray11[level][arg3][tileZ];
 				while (local20 != 0) {
 					local28 = (local20 & 0xFF) - 1;
 					local20 >>>= 0x8;
@@ -331,7 +331,7 @@ public class LightingManager {
 	}
 
 	@OriginalMember(owner = "client!jf", name = "c", descriptor = "()V")
-	public static void method2398() {
+	public static void clear() {
 		lights = null;
 		anIntArray284 = null;
 		enabledLights = null;
@@ -357,13 +357,13 @@ public class LightingManager {
 	}
 
 	@OriginalMember(owner = "client!jf", name = "f", descriptor = "()V")
-	public static void method2401() {
+	public static void init() {
 		lights = new Light[255];
 		anIntArray284 = new int[4];
 		enabledLights = new boolean[4];
 		anIntArray283 = new int[4];
 		aBooleanArray66 = new boolean[4];
-		anIntArrayArrayArray11 = new int[anInt3032][width][length];
+		anIntArrayArrayArray11 = new int[levels][width][length];
 	}
 
 	@OriginalMember(owner = "client!jf", name = "a", descriptor = "(II[[[Lclient!bj;)V")
@@ -453,10 +453,10 @@ public class LightingManager {
 	@OriginalMember(owner = "client!jf", name = "g", descriptor = "()V")
 	public static void method2404() {
 		lightCount = 0;
-		for (@Pc(3) int local3 = 0; local3 < anInt3032; local3++) {
-			for (@Pc(8) int local8 = 0; local8 < width; local8++) {
-				for (@Pc(13) int local13 = 0; local13 < length; local13++) {
-					anIntArrayArrayArray11[local3][local8][local13] = 0;
+		for (@Pc(3) int level = 0; level < levels; level++) {
+			for (@Pc(8) int x = 0; x < width; x++) {
+				for (@Pc(13) int z = 0; z < length; z++) {
+					anIntArrayArrayArray11[level][x][z] = 0;
 				}
 			}
 		}

--- a/client/src/main/java/rt4/LightingManager.java
+++ b/client/src/main/java/rt4/LightingManager.java
@@ -177,8 +177,8 @@ public class LightingManager {
 	}
 
 	@OriginalMember(owner = "client!jf", name = "a", descriptor = "(IIIIII)V")
-	public static void method2393(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5) {
-		if (!Preferences.highDetailLighting || anInt3031 == arg3 && anInt3033 == arg4 && anInt3029 == arg5 && anInt3035 == arg4 && anInt3030 == arg5) {
+	public static void method2393(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int z, @OriginalArg(3) int level, @OriginalArg(4) int nodeX, @OriginalArg(5) int nodeY) {
+		if (!Preferences.highDetailLighting || anInt3031 == level && anInt3033 == nodeX && anInt3029 == nodeY && anInt3035 == nodeX && anInt3030 == nodeY) {
 			return;
 		}
 		@Pc(20) int local20;
@@ -186,7 +186,7 @@ public class LightingManager {
 			aBooleanArray66[local20] = false;
 		}
 		local20 = 0;
-		@Pc(39) int local39 = anIntArrayArrayArray11[arg3][arg4][arg5];
+		@Pc(39) int local39 = anIntArrayArrayArray11[level][nodeX][nodeY];
 		while (true) {
 			@Pc(47) int local47;
 			@Pc(53) int local53;
@@ -207,7 +207,7 @@ public class LightingManager {
 					if (!aBooleanArray66[local53]) {
 						anIntArray284[local53] = anIntArray283[local47];
 						aBooleanArray66[local53] = true;
-						method2403(local53, lights[anIntArray283[local47]], arg0, arg1, arg2);
+						method2403(local53, lights[anIntArray283[local47]], x, y, z);
 						break;
 					}
 				}
@@ -218,11 +218,11 @@ public class LightingManager {
 					disableLight(local47);
 				}
 			}
-			anInt3031 = arg3;
-			anInt3033 = arg4;
-			anInt3029 = arg5;
-			anInt3035 = arg4;
-			anInt3030 = arg5;
+			anInt3031 = level;
+			anInt3033 = nodeX;
+			anInt3029 = nodeY;
+			anInt3035 = nodeX;
+			anInt3030 = nodeY;
 			return;
 		}
 	}

--- a/client/src/main/java/rt4/LightingManager.java
+++ b/client/src/main/java/rt4/LightingManager.java
@@ -383,42 +383,42 @@ public class LightingManager {
 		gl.glTexEnvi(GL2.GL_TEXTURE_ENV, GL2.GL_SRC0_RGB, GL2.GL_CONSTANT);
 		gl.glTexEnvi(GL2.GL_TEXTURE_ENV, GL2.GL_OPERAND0_RGB, GL2.GL_SRC_ALPHA);
 		label71:
-		for (@Pc(56) int local56 = 0; local56 < lightCount; local56++) {
-			@Pc(63) Light local63 = lights[local56];
-			@Pc(66) int local66 = local63.level;
-			if (local63.aBoolean125) {
-				local66--;
+		for (@Pc(56) int i = 0; i < lightCount; i++) {
+			@Pc(63) Light light = lights[i];
+			@Pc(66) int lightLevel = light.level;
+			if (light.aBoolean125) {
+				lightLevel--;
 			}
-			if (local63.aClass45_1 != null) {
-				@Pc(76) int local76 = 0;
-				@Pc(84) int local84 = (local63.z >> 7) - local63.radius;
-				@Pc(92) int local92 = (local63.z >> 7) + local63.radius;
-				if (local92 >= maximumVisibleZ) {
-					local92 = maximumVisibleZ - 1;
+			if (light.aClass45_1 != null) {
+				@Pc(76) int difference = 0;
+				@Pc(84) int negativeRadiusEdge = (light.z >> 7) - light.radius;
+				@Pc(92) int positiveRadiusEdge = (light.z >> 7) + light.radius;
+				if (positiveRadiusEdge >= maximumVisibleZ) {
+					positiveRadiusEdge = maximumVisibleZ - 1;
 				}
-				if (local84 < minimumVisibleZ) {
-					local76 = minimumVisibleZ - local84;
-					local84 = minimumVisibleZ;
+				if (negativeRadiusEdge < minimumVisibleZ) {
+					difference = minimumVisibleZ - negativeRadiusEdge;
+					negativeRadiusEdge = minimumVisibleZ;
 				}
-				for (@Pc(112) int local112 = local84; local112 <= local92; local112++) {
-					@Pc(121) short local121 = local63.aShortArray30[local76++];
-					@Pc(133) int local133 = (local63.x >> 7) + (local121 >> 8) - local63.radius;
-					@Pc(141) int local141 = local133 + (local121 & 0xFF) - 1;
-					if (local133 < minimumVisibleX) {
-						local133 = minimumVisibleX;
+				for (@Pc(112) int zD = negativeRadiusEdge; zD <= positiveRadiusEdge; zD++) {
+					@Pc(121) short local121 = light.aShortArray30[difference++];
+					@Pc(133) int radiusLeftEdge = (light.x >> 7) + (local121 >> 8) - light.radius;
+					@Pc(141) int radiusRightEdge = radiusLeftEdge + (local121 & 0xFF) - 1;
+					if (radiusLeftEdge < minimumVisibleX) {
+						radiusLeftEdge = minimumVisibleX;
 					}
-					if (local141 >= maximumVisibleX) {
-						local141 = maximumVisibleX - 1;
+					if (radiusRightEdge >= maximumVisibleX) {
+						radiusRightEdge = maximumVisibleX - 1;
 					}
-					for (@Pc(155) int local155 = local133; local155 <= local141; local155++) {
-						@Pc(160) Tile local160 = null;
-						if (local66 >= 0) {
-							local160 = arg2[local66][local155][local112];
+					for (@Pc(155) int xD = radiusLeftEdge; xD <= radiusRightEdge; xD++) {
+						@Pc(160) Tile tile = null;
+						if (lightLevel >= 0) {
+							tile = arg2[lightLevel][xD][zD];
 						}
-						if (local66 < 0 || local160 != null && local160.aBoolean45) {
-							GlRenderer.method4159(201.5F - (float) local63.level * 50.0F - 1.5F);
-							gl.glTexEnvfv(GL2.GL_TEXTURE_ENV, GL2.GL_TEXTURE_ENV_COLOR, new float[]{0.0F, 0.0F, 0.0F, local63.alpha}, 0);
-							local63.aClass45_1.method1556();
+						if (lightLevel < 0 || tile != null && tile.aBoolean45) {
+							GlRenderer.method4159(201.5F - (float) light.level * 50.0F - 1.5F);
+							gl.glTexEnvfv(GL2.GL_TEXTURE_ENV, GL2.GL_TEXTURE_ENV_COLOR, new float[]{0.0F, 0.0F, 0.0F, light.alpha}, 0);
+							light.aClass45_1.method1556();
 							continue label71;
 						}
 					}

--- a/client/src/main/java/rt4/LightingManager.java
+++ b/client/src/main/java/rt4/LightingManager.java
@@ -13,13 +13,13 @@ public class LightingManager {
 	@OriginalMember(owner = "client!jf", name = "a", descriptor = "[Lclient!gi;")
 	public static Light[] lights;
 	@OriginalMember(owner = "client!rh", name = "d", descriptor = "I")
-	public static int anInt4866;
+	public static int maximumVisibleZ;
 	@OriginalMember(owner = "client!aa", name = "m", descriptor = "I")
-	public static int anInt15;
+	public static int maximumVisibleX;
 	@OriginalMember(owner = "client!gf", name = "M", descriptor = "I")
-	public static int anInt4698;
+	public static int minimumVisibleZ;
 	@OriginalMember(owner = "client!ch", name = "w", descriptor = "I")
-	public static int anInt987;
+	public static int minimumVisibleX;
 	@OriginalMember(owner = "client!id", name = "b", descriptor = "I")
 	public static int anInt2875 = -1;
 	@OriginalMember(owner = "client!jf", name = "c", descriptor = "[I")
@@ -393,22 +393,22 @@ public class LightingManager {
 				@Pc(76) int local76 = 0;
 				@Pc(84) int local84 = (local63.z >> 7) - local63.radius;
 				@Pc(92) int local92 = (local63.z >> 7) + local63.radius;
-				if (local92 >= anInt4866) {
-					local92 = anInt4866 - 1;
+				if (local92 >= maximumVisibleZ) {
+					local92 = maximumVisibleZ - 1;
 				}
-				if (local84 < anInt4698) {
-					local76 = anInt4698 - local84;
-					local84 = anInt4698;
+				if (local84 < minimumVisibleZ) {
+					local76 = minimumVisibleZ - local84;
+					local84 = minimumVisibleZ;
 				}
 				for (@Pc(112) int local112 = local84; local112 <= local92; local112++) {
 					@Pc(121) short local121 = local63.aShortArray30[local76++];
 					@Pc(133) int local133 = (local63.x >> 7) + (local121 >> 8) - local63.radius;
 					@Pc(141) int local141 = local133 + (local121 & 0xFF) - 1;
-					if (local133 < anInt987) {
-						local133 = anInt987;
+					if (local133 < minimumVisibleX) {
+						local133 = minimumVisibleX;
 					}
-					if (local141 >= anInt15) {
-						local141 = anInt15 - 1;
+					if (local141 >= maximumVisibleX) {
+						local141 = maximumVisibleX - 1;
 					}
 					for (@Pc(155) int local155 = local133; local155 <= local141; local155++) {
 						@Pc(160) Tile local160 = null;

--- a/client/src/main/java/rt4/LoginManager.java
+++ b/client/src/main/java/rt4/LoginManager.java
@@ -1001,7 +1001,7 @@ public class LoginManager {
 		for (i = 0; i < 4; i++) {
 			for (chunkX = 0; chunkX < 104; chunkX++) {
 				for (chunkZ = 0; chunkZ < 104; chunkZ++) {
-					SceneGraph.renderFlags[i][chunkX][chunkZ] = 0;
+					SceneGraph.tileRenderFlags[i][chunkX][chunkZ] = 0;
 				}
 			}
 		}
@@ -1054,16 +1054,16 @@ public class LoginManager {
 			LightingManager.method2395();
 		}
 		ClientProt.ping(true);
-		i = SceneGraph.firstVisibleLevel;
+		i = SceneGraph.lastVisibleLevel;
 		if (i > Player.plane) {
 			i = Player.plane;
 		}
 		if (i < Player.plane - 1) {
 		}
 		if (SceneGraph.allLevelsAreVisible()) {
-			SceneGraph.method2750(0);
+			SceneGraph.initializeLevelMap(0);
 		} else {
-			SceneGraph.method2750(SceneGraph.firstVisibleLevel);
+			SceneGraph.initializeLevelMap(SceneGraph.lastVisibleLevel);
 		}
 		SceneGraph.unload();
 		if (GlRenderer.enabled && hasUnderWaterMap) {
@@ -1098,7 +1098,7 @@ public class LoginManager {
 				Protocol.spawnGroundObject(chunkZ, chunkX);
 			}
 		}
-		ScriptRunner.method2218();
+		ScriptRunner.setUpRemoveRoofTiles();
 		client.audioLoop();
 		ChangeLocRequest.flush();
 		client.unload();
@@ -1258,7 +1258,7 @@ public class LoginManager {
 						@Pc(154) CollisionMap local154 = null;
 						if (!arg7) {
 							@Pc(159) int local159 = arg1;
-							if ((SceneGraph.renderFlags[1][local120][local137] & 0x2) == 2) {
+							if ((SceneGraph.tileRenderFlags[1][local120][local137] & 0x2) == 2) {
 								local159 = arg1 - 1;
 							}
 							if (local159 >= 0) {

--- a/client/src/main/java/rt4/LoginManager.java
+++ b/client/src/main/java/rt4/LoginManager.java
@@ -1441,9 +1441,9 @@ public class LoginManager {
 			Cs1ScriptRunner.method182();
 		}
 		if (GlRenderer.enabled) {
-			GlRaster.method1177();
+			GlRaster.setFullClip();
 		} else {
-			SoftwareRaster.method2503();
+			SoftwareRaster.setFullClip();
 		}
 		if (!Cs1ScriptRunner.aBoolean108) {
 			PluginRepository.OnMiniMenuCreate();

--- a/client/src/main/java/rt4/LoginManager.java
+++ b/client/src/main/java/rt4/LoginManager.java
@@ -1051,7 +1051,7 @@ public class LoginManager {
 		ClientProt.ping(true);
 		SceneGraph.method1169(PathFinder.collisionMaps, false);
 		if (GlRenderer.enabled) {
-			LightingManager.method2395();
+			LightingManager.calculateLightRadiuses();
 		}
 		ClientProt.ping(true);
 		i = SceneGraph.lastVisibleLevel;

--- a/client/src/main/java/rt4/MapMarker.java
+++ b/client/src/main/java/rt4/MapMarker.java
@@ -10,7 +10,7 @@ public final class MapMarker {
 	public int anInt4045;
 
 	@OriginalMember(owner = "client!nc", name = "c", descriptor = "I")
-	public int anInt4046;
+	public int targetZ;
 
 	@OriginalMember(owner = "client!nc", name = "f", descriptor = "I")
 	public int anInt4047;

--- a/client/src/main/java/rt4/MiniMap.java
+++ b/client/src/main/java/rt4/MiniMap.java
@@ -124,10 +124,10 @@ public class MiniMap {
 			for (local37 = 1; local37 < 103; local37++) {
 				local76 = 4 * 512 * (103 - local37) + 24628;
 				for (local80 = 1; local80 < 103; local80++) {
-					if ((SceneGraph.renderFlags[arg0][local80][local37] & 0x18) == 0) {
+					if ((SceneGraph.tileRenderFlags[arg0][local80][local37] & 0x18) == 0) {
 						renderTile(local32, local76, arg0, local80, local37);
 					}
-					if (arg0 < 3 && (SceneGraph.renderFlags[arg0 + 1][local80][local37] & 0x8) != 0) {
+					if (arg0 < 3 && (SceneGraph.tileRenderFlags[arg0 + 1][local80][local37] & 0x8) != 0) {
 						renderTile(local32, local76, arg0 + 1, local80, local37);
 					}
 					local76 += 4;
@@ -187,7 +187,7 @@ public class MiniMap {
 		local35 = (int) (Math.random() * 20.0D) + 238 - 10 << 16;
 		for (local37 = 1; local37 < 103; local37++) {
 			for (local76 = 1; local76 < 103; local76++) {
-				if ((SceneGraph.renderFlags[arg0][local76][local37] & 0x18) == 0 && !method3109(local76, local455, local37, local35, arg0)) {
+				if ((SceneGraph.tileRenderFlags[arg0][local76][local37] & 0x18) == 0 && !method3109(local76, local455, local37, local35, arg0)) {
 					if (GlRenderer.enabled) {
 						SoftwareRaster.pixels = null;
 					} else {
@@ -195,7 +195,7 @@ public class MiniMap {
 					}
 					return false;
 				}
-				if (arg0 < 3 && (SceneGraph.renderFlags[arg0 + 1][local76][local37] & 0x8) != 0 && !method3109(local76, local455, local37, local35, arg0 + 1)) {
+				if (arg0 < 3 && (SceneGraph.tileRenderFlags[arg0 + 1][local76][local37] & 0x8) != 0 && !method3109(local76, local455, local37, local35, arg0 + 1)) {
 					if (GlRenderer.enabled) {
 						SoftwareRaster.pixels = null;
 					} else {

--- a/client/src/main/java/rt4/MiniMap.java
+++ b/client/src/main/java/rt4/MiniMap.java
@@ -46,14 +46,14 @@ public class MiniMap {
 
 	@OriginalMember(owner = "client!ma", name = "a", descriptor = "([IIIIII)V")
 	public static void renderTile(@OriginalArg(0) int[] pixels, @OriginalArg(1) int index, @OriginalArg(3) int arg2, @OriginalArg(4) int arg3, @OriginalArg(5) int arg4) {
-		@Pc(7) Tile local7 = SceneGraph.tiles[arg2][arg3][arg4];
-		if (local7 == null) {
+		@Pc(7) Tile tile = SceneGraph.tiles[arg2][arg3][arg4];
+		if (tile == null) {
 			return;
 		}
-		@Pc(13) PlainTile local13 = local7.plainTile;
+		@Pc(13) PlainTile plainTile = tile.plainTile;
 		@Pc(23) int local23;
-		if (local13 != null) {
-			@Pc(18) int local18 = local13.anInt4871;
+		if (plainTile != null) {
+			@Pc(18) int local18 = plainTile.anInt4871;
 			if (local18 != 0) {
 				for (local23 = 0; local23 < 4; local23++) {
 					pixels[index] = local18;
@@ -65,14 +65,14 @@ public class MiniMap {
 			}
 			return;
 		}
-		@Pc(58) ShapedTile local58 = local7.shapedTile;
-		if (local58 == null) {
+		@Pc(58) ShapedTile shapedTile = tile.shapedTile;
+		if (shapedTile == null) {
 			return;
 		}
-		local23 = local58.anInt1966;
-		@Pc(67) int local67 = local58.anInt1967;
-		@Pc(70) int local70 = local58.anInt1969;
-		@Pc(73) int local73 = local58.anInt1968;
+		local23 = shapedTile.anInt1966;
+		@Pc(67) int local67 = shapedTile.anInt1967;
+		@Pc(70) int local70 = shapedTile.anInt1969;
+		@Pc(73) int local73 = shapedTile.anInt1968;
 		@Pc(77) int[] local77 = anIntArrayArray24[local23];
 		@Pc(81) int[] local81 = anIntArrayArray46[local67];
 		@Pc(83) int local83 = 0;
@@ -377,7 +377,7 @@ public class MiniMap {
 					}
 					if (local770.type == 2) {
 						local154 = (local770.targetX - Camera.originX) * 4 + 2 - PlayerList.self.xFine / 32;
-						local231 = (-Camera.originZ + local770.anInt4046) * 4 + 2 - PlayerList.self.zFine / 32;
+						local231 = (-Camera.originZ + local770.targetZ) * 4 + 2 - PlayerList.self.zFine / 32;
 						method1960(local770.anInt4048, arg1, arg2, local154, local231, arg3);
 					}
 					if (local770.type == 10 && local770.actorTargetId >= 0 && PlayerList.players.length > local770.actorTargetId) {
@@ -518,7 +518,7 @@ public class MiniMap {
 		while (local5.length > local3) {
 			@Pc(17) MapMarker local17 = local5[local3];
 			if (local17 != null && local17.type == 2) {
-				ScriptRunner.method1026(arg0 >> 1, arg4, (local17.anInt4046 - Camera.originZ << 7) + local17.anInt4047, local17.anInt4050 * 2, arg2 >> 1, local17.anInt4045 + (local17.targetX - Camera.originX << 7), arg3);
+				ScriptRunner.method1026(arg0 >> 1, arg4, (local17.targetZ - Camera.originZ << 7) + local17.anInt4047, local17.anInt4050 * 2, arg2 >> 1, local17.anInt4045 + (local17.targetX - Camera.originX << 7), arg3);
 				if (ScriptRunner.anInt1951 > -1 && client.loop % 20 < 10) {
 					Sprites.headhints[local17.anInt4048].render(arg1 + ScriptRunner.anInt1951 - 12, arg5 + -28 - -ScriptRunner.anInt548);
 				}

--- a/client/src/main/java/rt4/Npc.java
+++ b/client/src/main/java/rt4/Npc.java
@@ -58,13 +58,13 @@ public final class Npc extends PathingEntity {
 		}
 
 		this.minY = body.getMinY();
-		@Pc(84) NpcType local84 = this.type;
-		if (local84.multiNpcs != null) {
-			local84 = local84.getMultiNpc();
+		@Pc(84) NpcType npcType = this.type;
+		if (npcType.multiNpcs != null) {
+			npcType = npcType.getMultiNpc();
 		}
 
 		@Pc(140) Model model;
-		if (Preferences.characterShadowsOn && local84.hasshadow) {
+		if (Preferences.characterShadowsOn && npcType.hasShadow) {
 			model = ShadowModelList.method1043(this.type.shadowcolormodifier1, this.aBoolean171, local53 == null ? local29 : local53, this.xFine, this.type.shadowcolor2, this.zFine, this.type.shadowcolor1, this.type.size, body, orientation, local53 == null ? this.anInt3425 : this.anInt3407, this.anInt3424, this.type.shadowcolormodifier2);
 			if (GlRenderer.enabled) {
 				@Pc(144) float local144 = GlRenderer.method4179();

--- a/client/src/main/java/rt4/NpcType.java
+++ b/client/src/main/java/rt4/NpcType.java
@@ -109,7 +109,7 @@ public final class NpcType {
 	public byte loginscreenproperties = 0;
 
 	@OriginalMember(owner = "client!me", name = "e", descriptor = "Z")
-	public boolean hasshadow = true;
+	public boolean hasShadow = true;
 
 	@OriginalMember(owner = "client!me", name = "ab", descriptor = "S")
 	public short shadowcolor1 = 0;
@@ -671,7 +671,7 @@ public final class NpcType {
 			} else if (opcode == 109) {
 				this.rotationflag = false;
 			} else if (opcode == 111) {
-				this.hasshadow = false;
+				this.hasShadow = false;
 			} else if (opcode == 113) {
 				this.shadowcolor1 = (short) buffer.g2();
 				this.shadowcolor2 = (short) buffer.g2();

--- a/client/src/main/java/rt4/ObjStackEntity.java
+++ b/client/src/main/java/rt4/ObjStackEntity.java
@@ -10,7 +10,7 @@ public final class ObjStackEntity {
 	public Entity secondary;
 
 	@OriginalMember(owner = "client!jj", name = "b", descriptor = "I")
-	public int anInt3057;
+	public int yFine;
 
 	@OriginalMember(owner = "client!jj", name = "c", descriptor = "Lclient!th;")
 	public Entity tertiary;
@@ -22,7 +22,7 @@ public final class ObjStackEntity {
 	public int zFine;
 
 	@OriginalMember(owner = "client!jj", name = "n", descriptor = "I")
-	public int anInt3063;
+	public int minY;
 
 	@OriginalMember(owner = "client!jj", name = "o", descriptor = "I")
 	public int xFine;

--- a/client/src/main/java/rt4/PlainTile.java
+++ b/client/src/main/java/rt4/PlainTile.java
@@ -26,7 +26,7 @@ public final class PlainTile {
 	public final int anInt4864;
 
 	@OriginalMember(owner = "client!rh", name = "i", descriptor = "I")
-	public final int anInt4869;
+	public final int tileTexture;
 
 	@OriginalMember(owner = "client!rh", name = "<init>", descriptor = "(IIIIIIZ)V")
 	public PlainTile(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5, @OriginalArg(6) boolean arg6) {
@@ -36,6 +36,6 @@ public final class PlainTile {
 		this.anInt4871 = arg5;
 		this.aBoolean241 = arg6;
 		this.anInt4864 = arg3;
-		this.anInt4869 = arg4;
+		this.tileTexture = arg4;
 	}
 }

--- a/client/src/main/java/rt4/Player.java
+++ b/client/src/main/java/rt4/Player.java
@@ -433,7 +433,7 @@ public final class Player extends PathingEntity {
 		}
 		this.minY = local76.getMinY();
 		@Pc(184) Model local184;
-		if (Preferences.characterShadowsOn && (this.appearance.npcId == -1 || NpcTypeList.get(this.appearance.npcId).hasshadow)) {
+		if (Preferences.characterShadowsOn && (this.appearance.npcId == -1 || NpcTypeList.get(this.appearance.npcId).hasShadow)) {
 			local184 = ShadowModelList.method1043(160, this.aBoolean171, local54 == null ? local25 : local54, this.xFine, 0, this.zFine, 0, 1, local76, arg0, local54 == null ? this.anInt3425 : this.anInt3407, this.anInt3424, 240);
 			if (GlRenderer.enabled) {
 				@Pc(188) float local188 = GlRenderer.method4179();

--- a/client/src/main/java/rt4/Player.java
+++ b/client/src/main/java/rt4/Player.java
@@ -212,65 +212,65 @@ public final class Player extends PathingEntity {
 		if (!GlRenderer.enabled || LoginManager.aBoolean252) {
 			return;
 		}
-		@Pc(14) Tile[][][] local14 = SceneGraph.tiles;
-		for (@Pc(22) int local22 = 0; local22 < local14.length; local22++) {
-			@Pc(30) Tile[][] local30 = local14[local22];
-			for (@Pc(32) int local32 = 0; local32 < local30.length; local32++) {
-				for (@Pc(42) int local42 = 0; local42 < local30[local32].length; local42++) {
-					@Pc(54) Tile local54 = local30[local32][local42];
-					if (local54 != null) {
+		@Pc(14) Tile[][][] worldTiles = SceneGraph.tiles;
+		for (@Pc(22) int level = 0; level < worldTiles.length; level++) {
+			@Pc(30) Tile[][] levelTiles = worldTiles[level];
+			for (@Pc(32) int x = 0; x < levelTiles.length; x++) {
+				for (@Pc(42) int z = 0; z < levelTiles[x].length; z++) {
+					@Pc(54) Tile tile = levelTiles[x][z];
+					if (tile != null) {
 						@Pc(71) GlModel local71;
-						if (local54.groundDecor != null && local54.groundDecor.entity instanceof GlModel) {
-							local71 = (GlModel) local54.groundDecor.entity;
-							if ((local54.groundDecor.key & Long.MIN_VALUE) == 0L) {
+						if (tile.groundDecor != null && tile.groundDecor.entity instanceof GlModel) {
+							local71 = (GlModel) tile.groundDecor.entity;
+							if ((tile.groundDecor.key & Long.MIN_VALUE) == 0L) {
 								local71.method4111(false, true, true, false, true, true);
 							} else {
 								local71.method4111(true, true, true, true, true, true);
 							}
 						}
-						if (local54.wallDecor != null) {
-							if (local54.wallDecor.primary instanceof GlModel) {
-								local71 = (GlModel) local54.wallDecor.primary;
-								if ((local54.wallDecor.key & Long.MIN_VALUE) == 0L) {
+						if (tile.wallDecor != null) {
+							if (tile.wallDecor.primary instanceof GlModel) {
+								local71 = (GlModel) tile.wallDecor.primary;
+								if ((tile.wallDecor.key & Long.MIN_VALUE) == 0L) {
 									local71.method4111(false, true, true, false, true, true);
 								} else {
 									local71.method4111(true, true, true, true, true, true);
 								}
 							}
-							if (local54.wallDecor.secondary instanceof GlModel) {
-								local71 = (GlModel) local54.wallDecor.secondary;
-								if ((Long.MIN_VALUE & local54.wallDecor.key) == 0L) {
-									local71.method4111(false, true, true, false, true, true);
-								} else {
-									local71.method4111(true, true, true, true, true, true);
-								}
-							}
-						}
-						if (local54.wall != null) {
-							if (local54.wall.primary instanceof GlModel) {
-								local71 = (GlModel) local54.wall.primary;
-								if ((local54.wall.key & Long.MIN_VALUE) == 0L) {
-									local71.method4111(false, true, true, false, true, true);
-								} else {
-									local71.method4111(true, true, true, true, true, true);
-								}
-							}
-							if (local54.wall.secondary instanceof GlModel) {
-								local71 = (GlModel) local54.wall.secondary;
-								if ((Long.MIN_VALUE & local54.wall.key) == 0L) {
+							if (tile.wallDecor.secondary instanceof GlModel) {
+								local71 = (GlModel) tile.wallDecor.secondary;
+								if ((Long.MIN_VALUE & tile.wallDecor.key) == 0L) {
 									local71.method4111(false, true, true, false, true, true);
 								} else {
 									local71.method4111(true, true, true, true, true, true);
 								}
 							}
 						}
-						for (@Pc(270) int local270 = 0; local270 < local54.sceneryLen; local270++) {
-							if (local54.scenery[local270].entity instanceof GlModel) {
-								@Pc(293) GlModel local293 = (GlModel) local54.scenery[local270].entity;
-								if ((Long.MIN_VALUE & local54.scenery[local270].key) == 0L) {
-									local293.method4111(false, true, true, false, true, true);
+						if (tile.wall != null) {
+							if (tile.wall.primary instanceof GlModel) {
+								local71 = (GlModel) tile.wall.primary;
+								if ((tile.wall.key & Long.MIN_VALUE) == 0L) {
+									local71.method4111(false, true, true, false, true, true);
 								} else {
-									local293.method4111(true, true, true, true, true, true);
+									local71.method4111(true, true, true, true, true, true);
+								}
+							}
+							if (tile.wall.secondary instanceof GlModel) {
+								local71 = (GlModel) tile.wall.secondary;
+								if ((Long.MIN_VALUE & tile.wall.key) == 0L) {
+									local71.method4111(false, true, true, false, true, true);
+								} else {
+									local71.method4111(true, true, true, true, true, true);
+								}
+							}
+						}
+						for (@Pc(270) int i = 0; i < tile.sceneryLen; i++) {
+							if (tile.scenery[i].entity instanceof GlModel) {
+								@Pc(293) GlModel sceneryEntity = (GlModel) tile.scenery[i].entity;
+								if ((Long.MIN_VALUE & tile.scenery[i].key) == 0L) {
+									sceneryEntity.method4111(false, true, true, false, true, true);
+								} else {
+									sceneryEntity.method4111(true, true, true, true, true, true);
 								}
 							}
 						}
@@ -463,7 +463,7 @@ public final class Player extends PathingEntity {
 					}
 					if (local245.type == 2) {
 						@Pc(340) int local340 = (local245.targetX - Camera.originX) * 4 + 2 - PlayerList.self.xFine / 32;
-						local291 = (local245.anInt4046 - Camera.originZ) * 4 + 2 - PlayerList.self.zFine / 32;
+						local291 = (local245.targetZ - Camera.originZ) * 4 + 2 - PlayerList.self.zFine / 32;
 						this.method1263(null, local291, local76, local340, arg5, arg9, arg0, arg7, arg4, arg3, arg1, local245.playerModelId, arg2, arg6);
 					}
 					if (local245.type == 10 && local245.actorTargetId >= 0 && PlayerList.players.length > local245.actorTargetId) {

--- a/client/src/main/java/rt4/Protocol.java
+++ b/client/src/main/java/rt4/Protocol.java
@@ -3428,36 +3428,36 @@ public class Protocol {
 	}
 
 	@OriginalMember(owner = "client!rm", name = "a", descriptor = "(IBI)V")
-	public static void spawnGroundObject(@OriginalArg(0) int arg0, @OriginalArg(2) int arg1) {
-		@Pc(9) LinkedList local9 = SceneGraph.objStacks[Player.plane][arg1][arg0];
-		if (local9 == null) {
-			SceneGraph.removeObjStack(Player.plane, arg1, arg0);
+	public static void spawnGroundObject(@OriginalArg(0) int z, @OriginalArg(2) int x) {
+		@Pc(9) LinkedList objStack = SceneGraph.objStacks[Player.plane][x][z];
+		if (objStack == null) {
+			SceneGraph.removeObjStack(Player.plane, x, z);
 			return;
 		}
-		@Pc(28) int local28 = -99999999;
-		@Pc(30) ObjStackNode local30 = null;
-		@Pc(35) ObjStackNode local35;
-		for (local35 = (ObjStackNode) local9.head(); local35 != null; local35 = (ObjStackNode) local9.next()) {
-			@Pc(44) ObjType local44 = ObjTypeList.get(local35.value.type);
-			@Pc(47) int local47 = local44.cost;
-			if (local44.stackable == 1) {
-				local47 *= local35.value.amount + 1;
+		@Pc(28) int cheapestCost = -99999999;
+		@Pc(30) ObjStackNode cheapestObj = null;
+		@Pc(35) ObjStackNode obj;
+		for (obj = (ObjStackNode) objStack.head(); obj != null; obj = (ObjStackNode) objStack.next()) {
+			@Pc(44) ObjType objType = ObjTypeList.get(obj.value.type);
+			@Pc(47) int cost = objType.cost;
+			if (objType.stackable == 1) {
+				cost *= obj.value.amount + 1;
 			}
-			if (local28 < local47) {
-				local28 = local47;
-				local30 = local35;
+			if (cheapestCost < cost) {
+				cheapestCost = cost;
+				cheapestObj = obj;
 			}
 		}
-		if (local30 == null) {
-			SceneGraph.removeObjStack(Player.plane, arg1, arg0);
+		if (cheapestObj == null) {
+			SceneGraph.removeObjStack(Player.plane, x, z);
 			return;
 		}
-		local9.addHead(local30);
+		objStack.addHead(cheapestObj);
 		@Pc(89) ObjStack local89 = null;
 		@Pc(91) ObjStack local91 = null;
-		for (local35 = (ObjStackNode) local9.head(); local35 != null; local35 = (ObjStackNode) local9.next()) {
-			@Pc(103) ObjStack local103 = local35.value;
-			if (local103.type != local30.value.type) {
+		for (obj = (ObjStackNode) objStack.head(); obj != null; obj = (ObjStackNode) objStack.next()) {
+			@Pc(103) ObjStack local103 = obj.value;
+			if (local103.type != cheapestObj.value.type) {
 				if (local89 == null) {
 					local89 = local103;
 				}
@@ -3466,8 +3466,8 @@ public class Protocol {
 				}
 			}
 		}
-		@Pc(152) long local152 = (arg0 << 7) + arg1 + 1610612736;
-		SceneGraph.setObjStack(Player.plane, arg1, arg0, SceneGraph.getTileHeight(Player.plane, arg1 * 128 + 64, arg0 * 128 + 64), local30.value, local152, local89, local91);
+		@Pc(152) long local152 = (z << 7) + x + 1610612736;
+		SceneGraph.setObjStack(Player.plane, x, z, SceneGraph.getTileHeight(Player.plane, x * 128 + 64, z * 128 + 64), cheapestObj.value, local152, local89, local91);
 	}
 
 	@OriginalMember(owner = "client!dh", name = "a", descriptor = "(IIII)Lclient!wk;")

--- a/client/src/main/java/rt4/Protocol.java
+++ b/client/src/main/java/rt4/Protocol.java
@@ -1905,7 +1905,7 @@ public class Protocol {
 					}
 					mapMarker.type = 2;
 					mapMarker.targetX = inboundBuffer.g2();
-					mapMarker.anInt4046 = inboundBuffer.g2();
+					mapMarker.targetZ = inboundBuffer.g2();
 					mapMarker.anInt4050 = inboundBuffer.g1();
 				}
 				mapMarker.playerModelId = inboundBuffer.g2();

--- a/client/src/main/java/rt4/SceneGraph.java
+++ b/client/src/main/java/rt4/SceneGraph.java
@@ -8,7 +8,7 @@ import org.openrs2.deob.annotation.Pc;
 public class SceneGraph {
 
 	@OriginalMember(owner = "client!bb", name = "g", descriptor = "[[[B")
-	public static final byte[][][] renderFlags = new byte[4][104][104];
+	public static final byte[][][] tileRenderFlags = new byte[4][104][104];
 	@OriginalMember(owner = "client!mi", name = "Y", descriptor = "[[[Lclient!ih;")
 	public static final LinkedList[][][] objStacks = new LinkedList[4][104][104];
 	@OriginalMember(owner = "client!te", name = "B", descriptor = "[I")
@@ -83,7 +83,7 @@ public class SceneGraph {
 	@OriginalMember(owner = "client!ka", name = "r", descriptor = "[I")
 	public static int[] rowCount;
 	@OriginalMember(owner = "client!lg", name = "k", descriptor = "I")
-	public static int firstVisibleLevel = 99;
+	public static int lastVisibleLevel = 99;
 	@OriginalMember(owner = "client!ug", name = "d", descriptor = "[I")
 	public static int[] rowChroma;
 	@OriginalMember(owner = "client!l", name = "l", descriptor = "[I")
@@ -131,7 +131,7 @@ public class SceneGraph {
 	@OriginalMember(owner = "client!wi", name = "db", descriptor = "I")
 	public static int visibility;
 	@OriginalMember(owner = "client!f", name = "ab", descriptor = "[[I")
-	public static int[][] anIntArrayArray11;
+	public static int[][] underWaterColors;
 	@OriginalMember(owner = "client!la", name = "i", descriptor = "[[[I")
 	public static int[][][] anIntArrayArrayArray12;
 	@OriginalMember(owner = "client!dl", name = "h", descriptor = "[[Z")
@@ -147,21 +147,21 @@ public class SceneGraph {
 	@OriginalMember(owner = "client!ok", name = "c", descriptor = "I")
 	public static int anInt4272 = (int) (Math.random() * 33.0D) - 16;
 	@OriginalMember(owner = "client!rj", name = "R", descriptor = "I")
-	public static int anInt4903;
+	public static int cameraZ;
 	@OriginalMember(owner = "client!pi", name = "U", descriptor = "I")
-	public static int anInt4539;
+	public static int cameraTileZ;
 	@OriginalMember(owner = "client!sk", name = "mb", descriptor = "I")
-	public static int anInt5205;
+	public static int yawSin;
 	@OriginalMember(owner = "client!bl", name = "X", descriptor = "I")
 	public static int anInt730 = -1;
 	@OriginalMember(owner = "client!aj", name = "Z", descriptor = "[I")
 	public static int[] anIntArray8;
 	@OriginalMember(owner = "client!jg", name = "a", descriptor = "I")
-	public static int anInt3038;
+	public static int pitchCos;
 	@OriginalMember(owner = "client!ma", name = "z", descriptor = "I")
 	public static int anInt3604 = -1;
 	@OriginalMember(owner = "client!ig", name = "i", descriptor = "I")
-	public static int anInt2886;
+	public static int pitchSin;
 	@OriginalMember(owner = "client!k", name = "l", descriptor = "[I")
 	public static int[] anIntArray292;
 	@OriginalMember(owner = "client!ta", name = "o", descriptor = "[I")
@@ -171,13 +171,13 @@ public class SceneGraph {
 	@OriginalMember(owner = "client!hh", name = "p", descriptor = "[I")
 	public static int[] anIntArray234;
 	@OriginalMember(owner = "client!ml", name = "K", descriptor = "I")
-	public static int anInt3947;
+	public static int cameraY;
 	@OriginalMember(owner = "client!nd", name = "s", descriptor = "I")
-	public static int anInt4069;
+	public static int cameraTileX;
 	@OriginalMember(owner = "client!lj", name = "B", descriptor = "I")
-	public static int anInt3555;
+	public static int cameraX;
 	@OriginalMember(owner = "client!tb", name = "Q", descriptor = "I")
-	public static int anInt5276 = 0;
+	public static int firstVisibleLevel = 0;
 	@OriginalMember(owner = "client!bc", name = "Z", descriptor = "I")
 	public static int anInt437;
 	@OriginalMember(owner = "client!rc", name = "p", descriptor = "I")
@@ -185,7 +185,7 @@ public class SceneGraph {
 	@OriginalMember(owner = "client!gn", name = "d", descriptor = "Z")
 	public static boolean aBoolean130 = false;
 	@OriginalMember(owner = "client!gg", name = "Z", descriptor = "I")
-	public static int anInt2222;
+	public static int yawCos;
 	@OriginalMember(owner = "client!sj", name = "u", descriptor = "Z")
 	public static boolean dynamicMapRegion = false;
 	@OriginalMember(owner = "client!gf", name = "R", descriptor = "I")
@@ -213,7 +213,7 @@ public class SceneGraph {
 		@Pc(36) int xFine2 = xFine & 0x7F;
 		@Pc(40) int zFine2 = zFine & 0x7F;
 		@Pc(42) int virtualLevel = level;
-		if (level < 3 && (renderFlags[1][x][z] & 0x2) == 2) {
+		if (level < 3 && (tileRenderFlags[1][x][z] & 0x2) == 2) {
 			virtualLevel = level + 1;
 		}
 		@Pc(91) int heightZ0 = xFine2 * tileHeights[virtualLevel][x + 1][z + 1] + tileHeights[virtualLevel][x][z + 1] * (128 - xFine2) >> 7;
@@ -335,7 +335,7 @@ public class SceneGraph {
 	public static void load(@OriginalArg(0) boolean underwater) {
 		rowWeightedHue = new int[104];
 		rowSaturation = new int[104];
-		firstVisibleLevel = 99;
+		lastVisibleLevel = 99;
 		rowChroma = new int[104];
 		@Pc(14) byte plane;
 		if (underwater) {
@@ -477,7 +477,7 @@ public class SceneGraph {
 			return;
 		}
 		if (!arg2) {
-			renderFlags[level][x][z] = 0;
+			tileRenderFlags[level][x][z] = 0;
 		}
 		while (true) {
 			opcode = buffer.g1();
@@ -514,7 +514,7 @@ public class SceneGraph {
 			} else if (opcode > 81) {
 				tileUnderlays[level][x][z] = (byte) (opcode - 81);
 			} else if (!arg2) {
-				renderFlags[level][x][z] = (byte) (opcode - 49);
+				tileRenderFlags[level][x][z] = (byte) (opcode - 49);
 			}
 		}
 	}
@@ -656,14 +656,14 @@ public class SceneGraph {
 		}
 		if (hasUnderWaterMap) {
 			underWaterGroundTiles = new Tile[1][width][length];
-			anIntArrayArray11 = new int[width][length];
+			underWaterColors = new int[width][length];
 			underwaterTileHeights = new int[1][width + 1][length + 1];
 			if (GlRenderer.enabled) {
 				underWaterHdTiles = new GlTile[1][];
 			}
 		} else {
 			underWaterGroundTiles = null;
-			anIntArrayArray11 = null;
+			underWaterColors = null;
 			underwaterTileHeights = null;
 			underWaterHdTiles = null;
 		}
@@ -783,9 +783,9 @@ public class SceneGraph {
 			for (level = 0; level < 4; level++) {
 				for (x = 0; x < 104; x++) {
 					for (@Pc(22) int z = 0; z < 104; z++) {
-						if ((renderFlags[level][x][z] & 0x1) == 1) {
+						if ((tileRenderFlags[level][x][z] & 0x1) == 1) {
 							@Pc(43) int transformedLevel = level;
-							if ((renderFlags[1][x][z] & 0x2) == 2) {
+							if ((tileRenderFlags[1][x][z] & 0x2) == 2) {
 								transformedLevel = level - 1;
 							}
 							if (transformedLevel >= 0) {
@@ -818,11 +818,11 @@ public class SceneGraph {
 		}
 		level = anInt2293 >> 2 << 10;
 		@Pc(142) int[][] local142 = new int[104][104];
-		@Pc(146) int[][] local146 = new int[104][104];
+		@Pc(146) int[][] underwaterOverlays = new int[104][104];
 		x = anInt4272 >> 1;
-		@Pc(152) int local152;
-		@Pc(168) int local168;
-		@Pc(173) int local173;
+		@Pc(152) int underwaterLevel;
+		@Pc(168) int underwaterX;
+		@Pc(173) int underwaterZ;
 		@Pc(178) int local178;
 		@Pc(194) int overlay;
 		@Pc(200) int local200;
@@ -832,92 +832,92 @@ public class SceneGraph {
 		@Pc(234) int local234;
 		@Pc(254) int local254;
 		@Pc(267) int local267;
-		for (local152 = 0; local152 < levels; local152++) {
-			@Pc(159) byte[][] local159 = shadowmap[local152];
+		for (underwaterLevel = 0; underwaterLevel < levels; underwaterLevel++) {
+			@Pc(159) byte[][] local159 = shadowmap[underwaterLevel];
 			@Pc(273) int local273;
 			@Pc(326) int local326;
 			@Pc(332) int local332;
 			@Pc(322) int local322;
 			if (!GlRenderer.enabled) {
-				local168 = (int) Math.sqrt(5100.0D);
-				local173 = local168 * 768 >> 8;
+				underwaterX = (int) Math.sqrt(5100.0D);
+				underwaterZ = underwaterX * 768 >> 8;
 				for (local178 = 1; local178 < 103; local178++) {
 					for (overlay = 1; overlay < 103; overlay++) {
-						local209 = tileHeights[local152][overlay][local178 + 1] - tileHeights[local152][overlay][local178 - 1];
-						local202 = tileHeights[local152][overlay + 1][local178] - tileHeights[local152][overlay - 1][local178];
+						local209 = tileHeights[underwaterLevel][overlay][local178 + 1] - tileHeights[underwaterLevel][overlay][local178 - 1];
+						local202 = tileHeights[underwaterLevel][overlay + 1][local178] - tileHeights[underwaterLevel][overlay - 1][local178];
 						local349 = (int) Math.sqrt(local202 * local202 + local209 * local209 + 65536);
 						local267 = (local209 << 8) / local349;
 						local254 = -65536 / local349;
 						local234 = (local202 << 8) / local349;
 						local273 = (local159[overlay][local178] >> 1) + (local159[overlay][local178 - 1] >> 2) + (local159[overlay - -1][local178] >> 3) + (local159[overlay - 1][local178] >> 2) + (local159[overlay][local178 + 1] >> 3);
-						local200 = (local267 * -50 + local234 * -50 + local254 * -10) / local173 + 74;
-						local146[overlay][local178] = local200 - local273;
+						local200 = (local267 * -50 + local234 * -50 + local254 * -10) / underwaterZ + 74;
+						underwaterOverlays[overlay][local178] = local200 - local273;
 					}
 				}
 			} else if (Preferences.highDetailLighting) {
-				for (local168 = 1; local168 < 103; local168++) {
-					for (local173 = 1; local173 < 103; local173++) {
-						overlay = (local159[local173 + 1][local168] >> 3) + (local159[local173 - 1][local168] >> 2) + (local159[local173][local168 + -1] >> 2) + (local159[local173][local168 + 1] >> 3) + (local159[local173][local168] >> 1);
-						local146[local173][local168] = 74 - overlay;
+				for (underwaterX = 1; underwaterX < 103; underwaterX++) {
+					for (underwaterZ = 1; underwaterZ < 103; underwaterZ++) {
+						overlay = (local159[underwaterZ + 1][underwaterX] >> 3) + (local159[underwaterZ - 1][underwaterX] >> 2) + (local159[underwaterZ][underwaterX + -1] >> 2) + (local159[underwaterZ][underwaterX + 1] >> 3) + (local159[underwaterZ][underwaterX] >> 1);
+						underwaterOverlays[underwaterZ][underwaterX] = 74 - overlay;
 					}
 				}
 			} else {
-				local168 = (int) FogManager.light0Position[0];
-				local173 = (int) FogManager.light0Position[1];
+				underwaterX = (int) FogManager.light0Position[0];
+				underwaterZ = (int) FogManager.light0Position[1];
 				local178 = (int) FogManager.light0Position[2];
-				overlay = (int) Math.sqrt(local173 * local173 + local168 * local168 + local178 * local178);
+				overlay = (int) Math.sqrt(underwaterZ * underwaterZ + underwaterX * underwaterX + local178 * local178);
 				local200 = overlay * 1024 >> 8;
 				for (local202 = 1; local202 < 103; local202++) {
 					for (local209 = 1; local209 < 103; local209++) {
-						local234 = tileHeights[local152][local209 + 1][local202] - tileHeights[local152][local209 - 1][local202];
-						local254 = tileHeights[local152][local209][local202 + 1] - tileHeights[local152][local209][local202 - 1];
+						local234 = tileHeights[underwaterLevel][local209 + 1][local202] - tileHeights[underwaterLevel][local209 - 1][local202];
+						local254 = tileHeights[underwaterLevel][local209][local202 + 1] - tileHeights[underwaterLevel][local209][local202 - 1];
 						local267 = (int) Math.sqrt(local234 * local234 + local254 * local254 + 65536);
 						local273 = (local234 << 8) / local267;
 						local322 = (local159[local209][local202 + 1] >> 3) + (local159[local209][local202 - 1] >> 2) + (local159[local209 - 1][local202] >> 2) + (local159[local209 + 1][local202] >> 3) + (local159[local209][local202] >> 1);
 						local326 = -65536 / local267;
 						local332 = (local254 << 8) / local267;
-						local349 = (local178 * local332 + local168 * local273 + local326 * local173) / local200 + 96;
-						local146[local209][local202] = local349 - (int) ((float) local322 * 1.7F);
+						local349 = (local178 * local332 + underwaterX * local273 + local326 * underwaterZ) / local200 + 96;
+						underwaterOverlays[local209][local202] = local349 - (int) ((float) local322 * 1.7F);
 					}
 				}
 			}
-			for (local168 = 0; local168 < 104; local168++) {
-				rowWeightedHue[local168] = 0;
-				rowSaturation[local168] = 0;
-				rowLightness[local168] = 0;
-				rowChroma[local168] = 0;
-				rowCount[local168] = 0;
+			for (underwaterX = 0; underwaterX < 104; underwaterX++) {
+				rowWeightedHue[underwaterX] = 0;
+				rowSaturation[underwaterX] = 0;
+				rowLightness[underwaterX] = 0;
+				rowChroma[underwaterX] = 0;
+				rowCount[underwaterX] = 0;
 			}
-			for (local168 = -5; local168 < 104; local168++) {
-				for (local173 = 0; local173 < 104; local173++) {
-					local178 = local168 + 5;
+			for (underwaterX = -5; underwaterX < 104; underwaterX++) {
+				for (underwaterZ = 0; underwaterZ < 104; underwaterZ++) {
+					local178 = underwaterX + 5;
 					@Pc(729) int local729;
 					if (local178 < 104) {
-						overlay = tileUnderlays[local152][local178][local173] & 0xFF;
+						overlay = tileUnderlays[underwaterLevel][local178][underwaterZ] & 0xFF;
 						if (overlay > 0) {
 							@Pc(693) FluType type = FluTypeList.get(overlay - 1);
-							rowWeightedHue[local173] += type.weightedHue;
-							rowSaturation[local173] += type.saturation;
-							rowLightness[local173] += type.lightness;
-							rowChroma[local173] += type.chroma;
-							local729 = rowCount[local173]++;
+							rowWeightedHue[underwaterZ] += type.weightedHue;
+							rowSaturation[underwaterZ] += type.saturation;
+							rowLightness[underwaterZ] += type.lightness;
+							rowChroma[underwaterZ] += type.chroma;
+							local729 = rowCount[underwaterZ]++;
 						}
 					}
-					overlay = local168 - 5;
+					overlay = underwaterX - 5;
 					if (overlay >= 0) {
-						local200 = tileUnderlays[local152][overlay][local173] & 0xFF;
+						local200 = tileUnderlays[underwaterLevel][overlay][underwaterZ] & 0xFF;
 						if (local200 > 0) {
 							@Pc(758) FluType local758 = FluTypeList.get(local200 - 1);
-							rowWeightedHue[local173] -= local758.weightedHue;
-							rowSaturation[local173] -= local758.saturation;
-							rowLightness[local173] -= local758.lightness;
-							rowChroma[local173] -= local758.chroma;
-							local729 = rowCount[local173]--;
+							rowWeightedHue[underwaterZ] -= local758.weightedHue;
+							rowSaturation[underwaterZ] -= local758.saturation;
+							rowLightness[underwaterZ] -= local758.lightness;
+							rowChroma[underwaterZ] -= local758.chroma;
+							local729 = rowCount[underwaterZ]--;
 						}
 					}
 				}
-				if (local168 >= 0) {
-					local173 = 0;
+				if (underwaterX >= 0) {
+					underwaterZ = 0;
 					overlay = 0;
 					local178 = 0;
 					local200 = 0;
@@ -927,7 +927,7 @@ public class SceneGraph {
 						if (local349 < 104) {
 							local178 += rowSaturation[local349];
 							local202 += rowCount[local349];
-							local173 += rowWeightedHue[local349];
+							underwaterZ += rowWeightedHue[local349];
 							local200 += rowChroma[local349];
 							overlay += rowLightness[local349];
 						}
@@ -935,44 +935,44 @@ public class SceneGraph {
 						if (local234 >= 0) {
 							local178 -= rowSaturation[local234];
 							local200 -= rowChroma[local234];
-							local173 -= rowWeightedHue[local234];
+							underwaterZ -= rowWeightedHue[local234];
 							local202 -= rowCount[local234];
 							overlay -= rowLightness[local234];
 						}
 						if (local209 >= 0 && local202 > 0) {
-							local142[local168][local209] = ColorUtils.method1309(overlay / local202, local178 / local202, local173 * 256 / local200);
+							local142[underwaterX][local209] = ColorUtils.method1309(overlay / local202, local178 / local202, underwaterZ * 256 / local200);
 						}
 					}
 				}
 			}
-			for (local168 = 1; local168 < 103; local168++) {
+			for (underwaterX = 1; underwaterX < 103; underwaterX++) {
 				label771:
-				for (local173 = 1; local173 < 103; local173++) {
-					if (underwater || allLevelsAreVisible() || (renderFlags[0][local168][local173] & 0x2) != 0 || (renderFlags[local152][local168][local173] & 0x10) == 0 && getRenderLevel(local173, local168, local152) == centralPlane) {
-						if (firstVisibleLevel > local152) {
-							firstVisibleLevel = local152;
+				for (underwaterZ = 1; underwaterZ < 103; underwaterZ++) {
+					if (underwater || allLevelsAreVisible() || (tileRenderFlags[0][underwaterX][underwaterZ] & 0x2) != 0 || (tileRenderFlags[underwaterLevel][underwaterX][underwaterZ] & 0x10) == 0 && getRenderLevel(underwaterZ, underwaterX, underwaterLevel) == centralPlane) {
+						if (lastVisibleLevel > underwaterLevel) {
+							lastVisibleLevel = underwaterLevel;
 						}
-						local178 = tileUnderlays[local152][local168][local173] & 0xFF;
-						overlay = tileOverlays[local152][local168][local173] & 0xFF;
+						local178 = tileUnderlays[underwaterLevel][underwaterX][underwaterZ] & 0xFF;
+						overlay = tileOverlays[underwaterLevel][underwaterX][underwaterZ] & 0xFF;
 						if (local178 > 0 || overlay > 0) {
-							local202 = tileHeights[local152][local168 + 1][local173];
-							local200 = tileHeights[local152][local168][local173];
-							local349 = tileHeights[local152][local168][local173 + 1];
-							local209 = tileHeights[local152][local168 + 1][local173 + 1];
-							if (local152 > 0) {
-								@Pc(1067) boolean local1067 = local178 != 0 || tileShapes[local152][local168][local173] == 0;
+							local202 = tileHeights[underwaterLevel][underwaterX + 1][underwaterZ];
+							local200 = tileHeights[underwaterLevel][underwaterX][underwaterZ];
+							local349 = tileHeights[underwaterLevel][underwaterX][underwaterZ + 1];
+							local209 = tileHeights[underwaterLevel][underwaterX + 1][underwaterZ + 1];
+							if (underwaterLevel > 0) {
+								@Pc(1067) boolean local1067 = local178 != 0 || tileShapes[underwaterLevel][underwaterX][underwaterZ] == 0;
 								if (overlay > 0 && !FloTypeList.method4395(overlay - 1).occludeUnderlay) {
 									local1067 = false;
 								}
 								if (local1067 && local200 == local202 && local200 == local209 && local349 == local200) {
-									occludeFlags[local152][local168][local173] |= 0x4;
+									occludeFlags[underwaterLevel][underwaterX][underwaterZ] |= 0x4;
 								}
 							}
 							if (local178 <= 0) {
 								local234 = -1;
 								local254 = 0;
 							} else {
-								local234 = local142[local168][local173];
+								local234 = local142[underwaterX][underwaterZ];
 								local267 = (local234 & 0x7F) + x;
 								if (local267 < 0) {
 									local267 = 0;
@@ -982,24 +982,24 @@ public class SceneGraph {
 								local273 = (local234 & 0x380) + (local234 + level & 0xFC00) + local267;
 								local254 = Rasteriser.palette[ColorUtils.multiplyLightnessSafe(96, local273)];
 							}
-							local267 = local146[local168][local173];
-							local332 = local146[local168][local173 + 1];
-							local273 = local146[local168 + 1][local173];
-							local326 = local146[local168 + 1][local173 + 1];
+							local267 = underwaterOverlays[underwaterX][underwaterZ];
+							local332 = underwaterOverlays[underwaterX][underwaterZ + 1];
+							local273 = underwaterOverlays[underwaterX + 1][underwaterZ];
+							local326 = underwaterOverlays[underwaterX + 1][underwaterZ + 1];
 							if (overlay == 0) {
-								setTile(local152, local168, local173, 0, 0, -1, local200, local202, local209, local349, ColorUtils.multiplyLightnessSafe(local267, local234), ColorUtils.multiplyLightnessSafe(local273, local234), ColorUtils.multiplyLightnessSafe(local326, local234), ColorUtils.multiplyLightnessSafe(local332, local234), 0, 0, 0, 0, local254, 0);
-								if (GlRenderer.enabled && local152 > 0 && local234 != -1 && FluTypeList.get(local178 - 1).blockShadow) {
-									ShadowManager.method4197(0, 0, true, false, local168, local173, local200 - tileHeights[0][local168][local173], -tileHeights[0][local168 + 1][local173] + local202, local209 - tileHeights[0][local168 + 1][local173 + 1], local349 - tileHeights[0][local168][local173 + 1]);
+								setTile(underwaterLevel, underwaterX, underwaterZ, 0, 0, -1, local200, local202, local209, local349, ColorUtils.multiplyLightnessSafe(local267, local234), ColorUtils.multiplyLightnessSafe(local273, local234), ColorUtils.multiplyLightnessSafe(local326, local234), ColorUtils.multiplyLightnessSafe(local332, local234), 0, 0, 0, 0, local254, 0);
+								if (GlRenderer.enabled && underwaterLevel > 0 && local234 != -1 && FluTypeList.get(local178 - 1).blockShadow) {
+									ShadowManager.method4197(0, 0, true, false, underwaterX, underwaterZ, local200 - tileHeights[0][underwaterX][underwaterZ], -tileHeights[0][underwaterX + 1][underwaterZ] + local202, local209 - tileHeights[0][underwaterX + 1][underwaterZ + 1], local349 - tileHeights[0][underwaterX][underwaterZ + 1]);
 								}
-								if (GlRenderer.enabled && !underwater && anIntArrayArray11 != null && local152 == 0) {
-									for (local322 = local168 - 1; local322 <= local168 + 1; local322++) {
-										for (@Pc(1794) int local1794 = local173 - 1; local1794 <= local173 + 1; local1794++) {
-											if ((local322 != local168 || local173 != local1794) && local322 >= 0 && local322 < 104 && local1794 >= 0 && local1794 < 104) {
-												@Pc(1834) int local1834 = tileOverlays[local152][local322][local1794] & 0xFF;
+								if (GlRenderer.enabled && !underwater && underWaterColors != null && underwaterLevel == 0) {
+									for (local322 = underwaterX - 1; local322 <= underwaterX + 1; local322++) {
+										for (@Pc(1794) int local1794 = underwaterZ - 1; local1794 <= underwaterZ + 1; local1794++) {
+											if ((local322 != underwaterX || underwaterZ != local1794) && local322 >= 0 && local322 < 104 && local1794 >= 0 && local1794 < 104) {
+												@Pc(1834) int local1834 = tileOverlays[underwaterLevel][local322][local1794] & 0xFF;
 												if (local1834 != 0) {
 													@Pc(1842) FloType local1842 = FloTypeList.method4395(local1834 - 1);
 													if (local1842.texture != -1 && Rasteriser.textureProvider.getMaterialType(local1842.texture) == MaterialManager.WATER) {
-														anIntArrayArray11[local168][local173] = local1842.waterColor + (local1842.waterOpacity << 24);
+														underWaterColors[underwaterX][underwaterZ] = local1842.waterColor + (local1842.waterOpacity << 24);
 														continue label771;
 													}
 												}
@@ -1008,25 +1008,25 @@ public class SceneGraph {
 									}
 								}
 							} else {
-								local322 = tileShapes[local152][local168][local173] + 1;
-								@Pc(1242) byte local1242 = tileAngles[local152][local168][local173];
+								local322 = tileShapes[underwaterLevel][underwaterX][underwaterZ] + 1;
+								@Pc(1242) byte local1242 = tileAngles[underwaterLevel][underwaterX][underwaterZ];
 								@Pc(1248) FloType local1248 = FloTypeList.method4395(overlay - 1);
-								@Pc(1301) int local1301;
-								@Pc(1353) int local1353;
-								@Pc(1288) int texture;
-								if (GlRenderer.enabled && !underwater && anIntArrayArray11 != null && local152 == 0) {
+								@Pc(1301) int textureY;
+								@Pc(1353) int floId;
+								@Pc(1288) int textureX;
+								if (GlRenderer.enabled && !underwater && underWaterColors != null && underwaterLevel == 0) {
 									if (local1248.texture != -1 && Rasteriser.textureProvider.getMaterialType(local1248.texture) == MaterialManager.WATER) {
-										anIntArrayArray11[local168][local173] = (local1248.waterOpacity << 24) + local1248.waterColor;
+										underWaterColors[underwaterX][underwaterZ] = (local1248.waterOpacity << 24) + local1248.waterColor;
 									} else {
 										label737:
-										for (texture = local168 - 1; texture <= local168 + 1; texture++) {
-											for (local1301 = local173 - 1; local1301 <= local173 + 1; local1301++) {
-												if ((local168 != texture || local1301 != local173) && texture >= 0 && texture < 104 && local1301 >= 0 && local1301 < 104) {
-													local1353 = tileOverlays[local152][texture][local1301] & 0xFF;
-													if (local1353 != 0) {
-														@Pc(1366) FloType local1366 = FloTypeList.method4395(local1353 - 1);
+										for (textureX = underwaterX - 1; textureX <= underwaterX + 1; textureX++) {
+											for (textureY = underwaterZ - 1; textureY <= underwaterZ + 1; textureY++) {
+												if ((underwaterX != textureX || textureY != underwaterZ) && textureX >= 0 && textureX < 104 && textureY >= 0 && textureY < 104) {
+													floId = tileOverlays[underwaterLevel][textureX][textureY] & 0xFF;
+													if (floId != 0) {
+														@Pc(1366) FloType local1366 = FloTypeList.method4395(floId - 1);
 														if (local1366.texture != -1 && Rasteriser.textureProvider.getMaterialType(local1366.texture) == MaterialManager.WATER) {
-															anIntArrayArray11[local168][local173] = local1366.waterColor + (local1366.waterOpacity << 24);
+															underWaterColors[underwaterX][underwaterZ] = local1366.waterColor + (local1366.waterOpacity << 24);
 															break label737;
 														}
 													}
@@ -1035,28 +1035,28 @@ public class SceneGraph {
 										}
 									}
 								}
-								texture = local1248.texture;
-								if (texture >= 0 && !Rasteriser.textureProvider.method3236(texture)) {
-									texture = -1;
+								textureX = local1248.texture;
+								if (textureX >= 0 && !Rasteriser.textureProvider.method3236(textureX)) {
+									textureX = -1;
 								}
 								@Pc(1458) int local1458;
 								@Pc(1429) int local1429;
-								if (texture >= 0) {
-									local1301 = -1;
-									local1353 = Rasteriser.palette[ColorUtils.multiplyLightnessGrayscale(Rasteriser.textureProvider.getAverageColor(texture), 96)];
+								if (textureX >= 0) {
+									textureY = -1;
+									floId = Rasteriser.palette[ColorUtils.multiplyLightnessGrayscale(Rasteriser.textureProvider.getAverageColor(textureX), 96)];
 								} else if (local1248.baseColor == -1) {
-									local1301 = -2;
-									local1353 = 0;
+									textureY = -2;
+									floId = 0;
 								} else {
-									local1301 = local1248.baseColor;
-									local1429 = x + (local1301 & 0x7F);
+									textureY = local1248.baseColor;
+									local1429 = x + (textureY & 0x7F);
 									if (local1429 < 0) {
 										local1429 = 0;
 									} else if (local1429 > 127) {
 										local1429 = 127;
 									}
-									local1458 = (local1301 & 0x380) + ((local1301 + level & 0xFC00) + local1429);
-									local1353 = Rasteriser.palette[ColorUtils.multiplyLightnessGrayscale(local1458, 96)];
+									local1458 = (textureY & 0x380) + ((textureY + level & 0xFC00) + local1429);
+									floId = Rasteriser.palette[ColorUtils.multiplyLightnessGrayscale(local1458, 96)];
 								}
 								if (local1248.secondaryColor >= 0) {
 									local1429 = local1248.secondaryColor;
@@ -1067,11 +1067,11 @@ public class SceneGraph {
 										local1458 = 127;
 									}
 									@Pc(1529) int local1529 = (local1429 & 0x380) + ((local1429 + level & 0xFC00) + local1458);
-									local1353 = Rasteriser.palette[ColorUtils.multiplyLightnessGrayscale(local1529, 96)];
+									floId = Rasteriser.palette[ColorUtils.multiplyLightnessGrayscale(local1529, 96)];
 								}
-								setTile(local152, local168, local173, local322, local1242, texture, local200, local202, local209, local349, ColorUtils.multiplyLightnessSafe(local267, local234), ColorUtils.multiplyLightnessSafe(local273, local234), ColorUtils.multiplyLightnessSafe(local326, local234), ColorUtils.multiplyLightnessSafe(local332, local234), ColorUtils.multiplyLightnessGrayscale(local1301, local267), ColorUtils.multiplyLightnessGrayscale(local1301, local273), ColorUtils.multiplyLightnessGrayscale(local1301, local326), ColorUtils.multiplyLightnessGrayscale(local1301, local332), local254, local1353);
-								if (GlRenderer.enabled && local152 > 0) {
-									ShadowManager.method4197(local322, local1242, local1301 == -2 || !local1248.aBoolean311, local234 == -1 || !FluTypeList.get(local178 - 1).blockShadow, local168, local173, local200 - tileHeights[0][local168][local173], local202 - tileHeights[0][local168 + 1][local173], local209 - tileHeights[0][local168 + 1][local173 + 1], -tileHeights[0][local168][local173 + 1] + local349);
+								setTile(underwaterLevel, underwaterX, underwaterZ, local322, local1242, textureX, local200, local202, local209, local349, ColorUtils.multiplyLightnessSafe(local267, local234), ColorUtils.multiplyLightnessSafe(local273, local234), ColorUtils.multiplyLightnessSafe(local326, local234), ColorUtils.multiplyLightnessSafe(local332, local234), ColorUtils.multiplyLightnessGrayscale(textureY, local267), ColorUtils.multiplyLightnessGrayscale(textureY, local273), ColorUtils.multiplyLightnessGrayscale(textureY, local326), ColorUtils.multiplyLightnessGrayscale(textureY, local332), local254, floId);
+								if (GlRenderer.enabled && underwaterLevel > 0) {
+									ShadowManager.method4197(local322, local1242, textureY == -2 || !local1248.aBoolean311, local234 == -1 || !FluTypeList.get(local178 - 1).blockShadow, underwaterX, underwaterZ, local200 - tileHeights[0][underwaterX][underwaterZ], local202 - tileHeights[0][underwaterX + 1][underwaterZ], local209 - tileHeights[0][underwaterX + 1][underwaterZ + 1], -tileHeights[0][underwaterX][underwaterZ + 1] + local349);
 								}
 							}
 						}
@@ -1080,7 +1080,7 @@ public class SceneGraph {
 			}
 			if (GlRenderer.enabled) {
 				@Pc(1888) float[][] local1888 = new float[105][105];
-				@Pc(1892) int[][] local1892 = tileHeights[local152];
+				@Pc(1892) int[][] local1892 = tileHeights[underwaterLevel];
 				@Pc(1896) float[][] local1896 = new float[105][105];
 				@Pc(1900) float[][] local1900 = new float[105][105];
 				local200 = 1;
@@ -1088,12 +1088,12 @@ public class SceneGraph {
 					if (local200 > 103) {
 						@Pc(2025) GlTile[] local2025;
 						if (underwater) {
-							local2025 = method3501(renderFlags, tileShapes[local152], tileUnderlays[local152], local146, local1896, anIntArrayArray11, tileOverlays[local152], tileAngles[local152], local1888, local152, local1900, local142, tileHeights[local152], surfaceTileHeights[0]);
-							method2280(local152, local2025);
+							local2025 = method3501(tileRenderFlags, tileShapes[underwaterLevel], tileUnderlays[underwaterLevel], underwaterOverlays, local1896, underWaterColors, tileOverlays[underwaterLevel], tileAngles[underwaterLevel], local1888, underwaterLevel, local1900, local142, tileHeights[underwaterLevel], surfaceTileHeights[0]);
+							method2280(underwaterLevel, local2025);
 							break;
 						}
-						local2025 = method3501(renderFlags, tileShapes[local152], tileUnderlays[local152], local146, local1896, null, tileOverlays[local152], tileAngles[local152], local1888, local152, local1900, local142, tileHeights[local152], null);
-						@Pc(2049) GlTile[] local2049 = method2(local1896, local1888, tileHeights[local152], local152, local1900, tileAngles[local152], local146, tileShapes[local152], tileUnderlays[local152], tileOverlays[local152], renderFlags);
+						local2025 = method3501(tileRenderFlags, tileShapes[underwaterLevel], tileUnderlays[underwaterLevel], underwaterOverlays, local1896, null, tileOverlays[underwaterLevel], tileAngles[underwaterLevel], local1888, underwaterLevel, local1900, local142, tileHeights[underwaterLevel], null);
+						@Pc(2049) GlTile[] local2049 = method2(local1896, local1888, tileHeights[underwaterLevel], underwaterLevel, local1900, tileAngles[underwaterLevel], underwaterOverlays, tileShapes[underwaterLevel], tileUnderlays[underwaterLevel], tileOverlays[underwaterLevel], tileRenderFlags);
 						@Pc(2057) GlTile[] local2057 = new GlTile[local2025.length + local2049.length];
 						for (local349 = 0; local349 < local2025.length; local349++) {
 							local2057[local349] = local2025[local349];
@@ -1101,8 +1101,8 @@ public class SceneGraph {
 						for (local349 = 0; local349 < local2049.length; local349++) {
 							local2057[local2025.length + local349] = local2049[local349];
 						}
-						method2280(local152, local2057);
-						method3393(local1900, tileUnderlays[local152], tileAngles[local152], LightingManager.lights, local152, LightingManager.lightCount, local1896, tileShapes[local152], tileOverlays[local152], tileHeights[local152], local1888);
+						method2280(underwaterLevel, local2057);
+						method3393(local1900, tileUnderlays[underwaterLevel], tileAngles[underwaterLevel], LightingManager.lights, underwaterLevel, LightingManager.lightCount, local1896, tileShapes[underwaterLevel], tileOverlays[underwaterLevel], tileHeights[underwaterLevel], local1888);
 						break;
 					}
 					for (local202 = 1; local202 <= 103; local202++) {
@@ -1116,38 +1116,38 @@ public class SceneGraph {
 					local200++;
 				}
 			}
-			tileUnderlays[local152] = null;
-			tileOverlays[local152] = null;
-			tileShapes[local152] = null;
-			tileAngles[local152] = null;
-			shadowmap[local152] = null;
+			tileUnderlays[underwaterLevel] = null;
+			tileOverlays[underwaterLevel] = null;
+			tileShapes[underwaterLevel] = null;
+			tileAngles[underwaterLevel] = null;
+			shadowmap[underwaterLevel] = null;
 		}
 		method3801();
 		if (underwater) {
 			return;
 		}
 		@Pc(2204) int local2204;
-		for (local152 = 0; local152 < 104; local152++) {
+		for (underwaterLevel = 0; underwaterLevel < 104; underwaterLevel++) {
 			for (local2204 = 0; local2204 < 104; local2204++) {
-				if ((renderFlags[1][local152][local2204] & 0x2) == 2) {
-					method3884(local152, local2204);
+				if ((tileRenderFlags[1][underwaterLevel][local2204] & 0x2) == 2) {
+					method3884(underwaterLevel, local2204);
 				}
 			}
 		}
-		for (local152 = 0; local152 < 4; local152++) {
+		for (underwaterLevel = 0; underwaterLevel < 4; underwaterLevel++) {
 			for (local2204 = 0; local2204 <= 104; local2204++) {
-				for (local168 = 0; local168 <= 104; local168++) {
-					if ((occludeFlags[local152][local168][local2204] & 0x1) != 0) {
-						local200 = local152;
-						for (local173 = local2204; local173 > 0 && (occludeFlags[local152][local168][local173 - 1] & 0x1) != 0; local173--) {
+				for (underwaterX = 0; underwaterX <= 104; underwaterX++) {
+					if ((occludeFlags[underwaterLevel][underwaterX][local2204] & 0x1) != 0) {
+						local200 = underwaterLevel;
+						for (underwaterZ = local2204; underwaterZ > 0 && (occludeFlags[underwaterLevel][underwaterX][underwaterZ - 1] & 0x1) != 0; underwaterZ--) {
 						}
-						overlay = local152;
-						for (local178 = local2204; local178 < 104 && (occludeFlags[local152][local168][local178 + 1] & 0x1) != 0; local178++) {
+						overlay = underwaterLevel;
+						for (local178 = local2204; local178 < 104 && (occludeFlags[underwaterLevel][underwaterX][local178 + 1] & 0x1) != 0; local178++) {
 						}
 						label454:
 						while (overlay > 0) {
-							for (local202 = local173; local202 <= local178; local202++) {
-								if ((occludeFlags[overlay - 1][local168][local202] & 0x1) == 0) {
+							for (local202 = underwaterZ; local202 <= local178; local202++) {
+								if ((occludeFlags[overlay - 1][underwaterX][local202] & 0x1) == 0) {
 									break label454;
 								}
 							}
@@ -1155,35 +1155,35 @@ public class SceneGraph {
 						}
 						label443:
 						while (local200 < 3) {
-							for (local202 = local173; local202 <= local178; local202++) {
-								if ((occludeFlags[local200 + 1][local168][local202] & 0x1) == 0) {
+							for (local202 = underwaterZ; local202 <= local178; local202++) {
+								if ((occludeFlags[local200 + 1][underwaterX][local202] & 0x1) == 0) {
 									break label443;
 								}
 							}
 							local200++;
 						}
-						local202 = (local200 + 1 - overlay) * (-local173 + (local178 - -1));
+						local202 = (local200 + 1 - overlay) * (-underwaterZ + (local178 - -1));
 						if (local202 >= 8) {
-							local349 = tileHeights[local200][local168][local173] - 240;
-							local234 = tileHeights[overlay][local168][local173];
-							SceneGraph_Class120.method4647(1, local168 * 128, local168 * 128, local173 * 128, local178 * 128 + 128, local349, local234);
+							local349 = tileHeights[local200][underwaterX][underwaterZ] - 240;
+							local234 = tileHeights[overlay][underwaterX][underwaterZ];
+							SceneGraph_Class120.method4647(1, underwaterX * 128, underwaterX * 128, underwaterZ * 128, local178 * 128 + 128, local349, local234);
 							for (local254 = overlay; local254 <= local200; local254++) {
-								for (local267 = local173; local267 <= local178; local267++) {
-									occludeFlags[local254][local168][local267] &= 0xFFFFFFFE;
+								for (local267 = underwaterZ; local267 <= local178; local267++) {
+									occludeFlags[local254][underwaterX][local267] &= 0xFFFFFFFE;
 								}
 							}
 						}
 					}
-					if ((occludeFlags[local152][local168][local2204] & 0x2) != 0) {
-						for (local173 = local168; local173 > 0 && (occludeFlags[local152][local173 - 1][local2204] & 0x2) != 0; local173--) {
+					if ((occludeFlags[underwaterLevel][underwaterX][local2204] & 0x2) != 0) {
+						for (underwaterZ = underwaterX; underwaterZ > 0 && (occludeFlags[underwaterLevel][underwaterZ - 1][local2204] & 0x2) != 0; underwaterZ--) {
 						}
-						local200 = local152;
-						overlay = local152;
-						for (local178 = local168; local178 < 104 && (occludeFlags[local152][local178 + 1][local2204] & 0x2) != 0; local178++) {
+						local200 = underwaterLevel;
+						overlay = underwaterLevel;
+						for (local178 = underwaterX; local178 < 104 && (occludeFlags[underwaterLevel][local178 + 1][local2204] & 0x2) != 0; local178++) {
 						}
 						label508:
 						while (overlay > 0) {
-							for (local202 = local173; local202 <= local178; local202++) {
+							for (local202 = underwaterZ; local202 <= local178; local202++) {
 								if ((occludeFlags[overlay - 1][local202][local2204] & 0x2) == 0) {
 									break label508;
 								}
@@ -1192,56 +1192,56 @@ public class SceneGraph {
 						}
 						label497:
 						while (local200 < 3) {
-							for (local202 = local173; local202 <= local178; local202++) {
+							for (local202 = underwaterZ; local202 <= local178; local202++) {
 								if ((occludeFlags[local200 + 1][local202][local2204] & 0x2) == 0) {
 									break label497;
 								}
 							}
 							local200++;
 						}
-						local202 = (local178 + 1 - local173) * (-overlay + local200 - -1);
+						local202 = (local178 + 1 - underwaterZ) * (-overlay + local200 - -1);
 						if (local202 >= 8) {
-							local349 = tileHeights[local200][local173][local2204] - 240;
-							local234 = tileHeights[overlay][local173][local2204];
-							SceneGraph_Class120.method4647(2, local173 * 128, local178 * 128 + 128, local2204 * 128, local2204 * 128, local349, local234);
+							local349 = tileHeights[local200][underwaterZ][local2204] - 240;
+							local234 = tileHeights[overlay][underwaterZ][local2204];
+							SceneGraph_Class120.method4647(2, underwaterZ * 128, local178 * 128 + 128, local2204 * 128, local2204 * 128, local349, local234);
 							for (local254 = overlay; local254 <= local200; local254++) {
-								for (local267 = local173; local267 <= local178; local267++) {
+								for (local267 = underwaterZ; local267 <= local178; local267++) {
 									occludeFlags[local254][local267][local2204] &= 0xFFFFFFFD;
 								}
 							}
 						}
 					}
-					if ((occludeFlags[local152][local168][local2204] & 0x4) != 0) {
-						local173 = local168;
-						local178 = local168;
-						for (overlay = local2204; overlay > 0 && (occludeFlags[local152][local168][overlay - 1] & 0x4) != 0; overlay--) {
+					if ((occludeFlags[underwaterLevel][underwaterX][local2204] & 0x4) != 0) {
+						underwaterZ = underwaterX;
+						local178 = underwaterX;
+						for (overlay = local2204; overlay > 0 && (occludeFlags[underwaterLevel][underwaterX][overlay - 1] & 0x4) != 0; overlay--) {
 						}
-						for (local200 = local2204; local200 < 104 && (occludeFlags[local152][local168][local200 + 1] & 0x4) != 0; local200++) {
+						for (local200 = local2204; local200 < 104 && (occludeFlags[underwaterLevel][underwaterX][local200 + 1] & 0x4) != 0; local200++) {
 						}
 						label562:
-						while (local173 > 0) {
+						while (underwaterZ > 0) {
 							for (local202 = overlay; local202 <= local200; local202++) {
-								if ((occludeFlags[local152][local173 - 1][local202] & 0x4) == 0) {
+								if ((occludeFlags[underwaterLevel][underwaterZ - 1][local202] & 0x4) == 0) {
 									break label562;
 								}
 							}
-							local173--;
+							underwaterZ--;
 						}
 						label551:
 						while (local178 < 104) {
 							for (local202 = overlay; local202 <= local200; local202++) {
-								if ((occludeFlags[local152][local178 + 1][local202] & 0x4) == 0) {
+								if ((occludeFlags[underwaterLevel][local178 + 1][local202] & 0x4) == 0) {
 									break label551;
 								}
 							}
 							local178++;
 						}
-						if ((local178 + 1 - local173) * (local200 - (overlay - 1)) >= 4) {
-							local202 = tileHeights[local152][local173][overlay];
-							SceneGraph_Class120.method4647(4, local173 * 128, local178 * 128 + 128, overlay * 128, local200 * 128 + 128, local202, local202);
-							for (local209 = local173; local209 <= local178; local209++) {
+						if ((local178 + 1 - underwaterZ) * (local200 - (overlay - 1)) >= 4) {
+							local202 = tileHeights[underwaterLevel][underwaterZ][overlay];
+							SceneGraph_Class120.method4647(4, underwaterZ * 128, local178 * 128 + 128, overlay * 128, local200 * 128 + 128, local202, local202);
+							for (local209 = underwaterZ; local209 <= local178; local209++) {
 								for (local349 = overlay; local349 <= local200; local349++) {
-									occludeFlags[local152][local209][local349] &= 0xFFFFFFFB;
+									occludeFlags[underwaterLevel][local209][local349] &= 0xFFFFFFFB;
 								}
 							}
 						}
@@ -1323,16 +1323,16 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!ib", name = "a", descriptor = "(IIIIIIIILclient!th;IZJ)Z")
-	public static boolean method2256(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5, @OriginalArg(6) int arg6, @OriginalArg(7) int arg7, @OriginalArg(8) Entity arg8, @OriginalArg(9) int arg9, @OriginalArg(10) boolean arg10, @OriginalArg(11) long arg11) {
+	public static boolean method2256(@OriginalArg(0) int highestLevel, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5, @OriginalArg(6) int arg6, @OriginalArg(7) int arg7, @OriginalArg(8) Entity arg8, @OriginalArg(9) int arg9, @OriginalArg(10) boolean arg10, @OriginalArg(11) long arg11) {
 		@Pc(6) boolean local6 = tileHeights == underwaterTileHeights;
 		@Pc(8) int local8 = 0;
-		@Pc(17) int local17;
+		@Pc(17) int x;
 		for (@Pc(10) int local10 = arg1; local10 < arg1 + arg3; local10++) {
-			for (local17 = arg2; local17 < arg2 + arg4; local17++) {
-				if (local10 < 0 || local17 < 0 || local10 >= width || local17 >= length) {
+			for (x = arg2; x < arg2 + arg4; x++) {
+				if (local10 < 0 || x < 0 || local10 >= width || x >= length) {
 					return false;
 				}
-				@Pc(42) Tile local42 = tiles[arg0][local10][local17];
+				@Pc(42) Tile local42 = tiles[highestLevel][local10][x];
 				if (local42 != null && local42.sceneryLen >= 5) {
 					return false;
 				}
@@ -1340,7 +1340,7 @@ public class SceneGraph {
 		}
 		@Pc(58) Scenery local58 = new Scenery();
 		local58.key = arg11;
-		local58.level = arg0;
+		local58.level = highestLevel;
 		local58.anInt1699 = arg5;
 		local58.anInt1703 = arg6;
 		local58.anInt1706 = arg7;
@@ -1350,42 +1350,42 @@ public class SceneGraph {
 		local58.zMin = arg2;
 		local58.xMax = arg1 + arg3 - 1;
 		local58.zMax = arg2 + arg4 - 1;
-		@Pc(108) int local108;
-		for (local17 = arg1; local17 < arg1 + arg3; local17++) {
-			for (local108 = arg2; local108 < arg2 + arg4; local108++) {
+		@Pc(108) int y;
+		for (x = arg1; x < arg1 + arg3; x++) {
+			for (y = arg2; y < arg2 + arg4; y++) {
 				@Pc(115) int local115 = 0;
-				if (local17 > arg1) {
+				if (x > arg1) {
 					local115++;
 				}
-				if (local17 < arg1 + arg3 - 1) {
+				if (x < arg1 + arg3 - 1) {
 					local115 += 4;
 				}
-				if (local108 > arg2) {
+				if (y > arg2) {
 					local115 += 8;
 				}
-				if (local108 < arg2 + arg4 - 1) {
+				if (y < arg2 + arg4 - 1) {
 					local115 += 2;
 				}
-				for (@Pc(141) int local141 = arg0; local141 >= 0; local141--) {
-					if (tiles[local141][local17][local108] == null) {
-						tiles[local141][local17][local108] = new Tile(local141, local17, local108);
+				for (@Pc(141) int level = highestLevel; level >= 0; level--) {
+					if (tiles[level][x][y] == null) {
+						tiles[level][x][y] = new Tile(level, x, y);
 					}
 				}
-				@Pc(174) Tile local174 = tiles[arg0][local17][local108];
-				local174.scenery[local174.sceneryLen] = local58;
-				local174.interiorFlags[local174.sceneryLen] = local115;
-				local174.allInteriorFlags |= local115;
-				local174.sceneryLen++;
-				if (local6 && anIntArrayArray11[local17][local108] != 0) {
-					local8 = anIntArrayArray11[local17][local108];
+				@Pc(174) Tile highestTile = tiles[highestLevel][x][y];
+				highestTile.scenery[highestTile.sceneryLen] = local58;
+				highestTile.interiorFlags[highestTile.sceneryLen] = local115;
+				highestTile.allInteriorFlags |= local115;
+				highestTile.sceneryLen++;
+				if (local6 && underWaterColors[x][y] != 0) {
+					local8 = underWaterColors[x][y];
 				}
 			}
 		}
 		if (local6 && local8 != 0) {
-			for (local17 = arg1; local17 < arg1 + arg3; local17++) {
-				for (local108 = arg2; local108 < arg2 + arg4; local108++) {
-					if (anIntArrayArray11[local17][local108] == 0) {
-						anIntArrayArray11[local17][local108] = local8;
+			for (x = arg1; x < arg1 + arg3; x++) {
+				for (y = arg2; y < arg2 + arg4; y++) {
+					if (underWaterColors[x][y] == 0) {
+						underWaterColors[x][y] = local8;
 					}
 				}
 			}
@@ -1539,25 +1539,25 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!sd", name = "c", descriptor = "(II)V")
-	public static void method3884(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1) {
-		@Pc(7) Tile local7 = tiles[0][arg0][arg1];
-		for (@Pc(9) int local9 = 0; local9 < 3; local9++) {
-			@Pc(30) Tile local30 = tiles[local9][arg0][arg1] = tiles[local9 + 1][arg0][arg1];
-			if (local30 != null) {
-				local30.anInt672--;
-				for (@Pc(40) int local40 = 0; local40 < local30.sceneryLen; local40++) {
-					@Pc(49) Scenery local49 = local30.scenery[local40];
-					if ((local49.key >> 29 & 0x3L) == 2L && local49.xMin == arg0 && local49.zMin == arg1) {
+	public static void method3884(@OriginalArg(0) int x, @OriginalArg(1) int y) {
+		@Pc(7) Tile firstLevelTile = tiles[0][x][y];
+		for (@Pc(9) int level = 0; level < 3; level++) {
+			@Pc(30) Tile tile = tiles[level][x][y] = tiles[level + 1][x][y];
+			if (tile != null) {
+				tile.level--;
+				for (@Pc(40) int local40 = 0; local40 < tile.sceneryLen; local40++) {
+					@Pc(49) Scenery local49 = tile.scenery[local40];
+					if ((local49.key >> 29 & 0x3L) == 2L && local49.xMin == x && local49.zMin == y) {
 						local49.level--;
 					}
 				}
 			}
 		}
-		if (tiles[0][arg0][arg1] == null) {
-			tiles[0][arg0][arg1] = new Tile(0, arg0, arg1);
+		if (tiles[0][x][y] == null) {
+			tiles[0][x][y] = new Tile(0, x, y);
 		}
-		tiles[0][arg0][arg1].aClass3_Sub5_1 = local7;
-		tiles[3][arg0][arg1] = null;
+		tiles[0][x][y].aClass3_Sub5_1 = firstLevelTile;
+		tiles[3][x][y] = null;
 	}
 
 	@OriginalMember(owner = "client!fm", name = "a", descriptor = "(IIIIII)Z")
@@ -1604,7 +1604,7 @@ public class SceneGraph {
 		wallDecor.key = key;
 		wallDecor.xFine = x * 128 + 64;
 		wallDecor.zFine = z * 128 + 64;
-		wallDecor.anInt1391 = arg3;
+		wallDecor.yFine = arg3;
 		wallDecor.primary = primary;
 		wallDecor.secondary = secondary;
 		wallDecor.anInt1395 = arg6;
@@ -1635,13 +1635,13 @@ public class SceneGraph {
 	public static void method4245(@OriginalArg(0) Tile arg0, @OriginalArg(1) boolean arg1) {
 		aClass69_32.addTail(arg0);
 		while (true) {
-			@Pc(8) Tile local8;
-			@Pc(18) int local18;
-			@Pc(21) int local21;
-			@Pc(24) int local24;
-			@Pc(27) int local27;
-			@Pc(31) Tile[][] local31;
-			@Pc(65) int local65;
+			@Pc(8) Tile node;
+			@Pc(18) int nodeX;
+			@Pc(21) int nodeY;
+			@Pc(24) int level;
+			@Pc(27) int plane;
+			@Pc(31) Tile[][] levelTiles;
+			@Pc(65) int sceneryIndex;
 			@Pc(115) int local115;
 			@Pc(894) int local894;
 			@Pc(899) int local899;
@@ -1655,117 +1655,117 @@ public class SceneGraph {
 							do {
 								do {
 									while (true) {
-										@Pc(44) int var9;
+										@Pc(44) int sceneryLength;
 										@Pc(48) int var10;
 										@Pc(907) int var17;
 										@Pc(916) int var18;
 										@Pc(363) Wall var22;
 										@Pc(469) boolean var24;
-										@Pc(425) Scenery var25;
+										@Pc(425) Scenery scenery;
 										@Pc(1179) Tile var32;
 										while (true) {
 											do {
-												local8 = (Tile) aClass69_32.removeHead();
-												if (local8 == null) {
+												node = (Tile) aClass69_32.removeHead();
+												if (node == null) {
 													return;
 												}
-											} while (!local8.aBoolean46);
-											local18 = local8.anInt669;
-											local21 = local8.anInt666;
-											local24 = local8.anInt672;
-											local27 = local8.anInt668;
-											local31 = tiles[local24];
+											} while (!node.aBoolean46);
+											nodeX = node.x;
+											nodeY = node.y;
+											level = node.level;
+											plane = node.plane;
+											levelTiles = tiles[level];
 											@Pc(33) float local33 = 0.0F;
 											if (GlRenderer.enabled) {
 												if (underwaterTileHeights == tileHeights) {
-													var9 = anIntArrayArray11[local18][local21];
-													var10 = var9 & 0xFFFFFF;
+													sceneryLength = underWaterColors[nodeX][nodeY];
+													var10 = sceneryLength & 0xFFFFFF;
 													if (var10 != anInt3604) {
 														anInt3604 = var10;
 														WaterMaterialRenderer.method619(var10);
 														FogManager.setFogColor(WaterMaterialRenderer.method2422());
 													}
-													local65 = var9 >>> 24 << 3;
-													if (local65 != anInt730) {
-														anInt730 = local65;
-														MaterialManager.method2761(local65);
+													sceneryIndex = sceneryLength >>> 24 << 3;
+													if (sceneryIndex != anInt730) {
+														anInt730 = sceneryIndex;
+														MaterialManager.method2761(sceneryIndex);
 													}
-													local115 = surfaceTileHeights[0][local18][local21] + surfaceTileHeights[0][local18 + 1][local21] + surfaceTileHeights[0][local18][local21 + 1] + surfaceTileHeights[0][local18 + 1][local21 + 1] >> 2;
+													local115 = surfaceTileHeights[0][nodeX][nodeY] + surfaceTileHeights[0][nodeX + 1][nodeY] + surfaceTileHeights[0][nodeX][nodeY + 1] + surfaceTileHeights[0][nodeX + 1][nodeY + 1] >> 2;
 													MaterialManager.setMaterial(-local115, 3);
 													local33 = 201.5F;
 													GlRenderer.method4159(local33);
 												} else {
-													local33 = 201.5F - (float) (local27 + 1) * 50.0F;
+													local33 = 201.5F - (float) (plane + 1) * 50.0F;
 													GlRenderer.method4159(local33);
 												}
 											}
-											if (!local8.aBoolean45) {
+											if (!node.aBoolean45) {
 												break;
 											}
 											if (arg1) {
-												if (local24 > 0) {
-													local153 = tiles[local24 - 1][local18][local21];
+												if (level > 0) {
+													local153 = tiles[level - 1][nodeX][nodeY];
 													if (local153 != null && local153.aBoolean46) {
 														continue;
 													}
 												}
-												if (local18 <= anInt4069 && local18 > LightingManager.anInt987) {
-													local153 = local31[local18 - 1][local21];
-													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (local8.allInteriorFlags & 0x1) == 0)) {
+												if (nodeX <= cameraTileX && nodeX > LightingManager.anInt987) {
+													local153 = levelTiles[nodeX - 1][nodeY];
+													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x1) == 0)) {
 														continue;
 													}
 												}
-												if (local18 >= anInt4069 && local18 < LightingManager.anInt15 - 1) {
-													local153 = local31[local18 + 1][local21];
-													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (local8.allInteriorFlags & 0x4) == 0)) {
+												if (nodeX >= cameraTileX && nodeX < LightingManager.anInt15 - 1) {
+													local153 = levelTiles[nodeX + 1][nodeY];
+													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x4) == 0)) {
 														continue;
 													}
 												}
-												if (local21 <= anInt4539 && local21 > LightingManager.anInt4698) {
-													local153 = local31[local18][local21 - 1];
-													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (local8.allInteriorFlags & 0x8) == 0)) {
+												if (nodeY <= cameraTileZ && nodeY > LightingManager.anInt4698) {
+													local153 = levelTiles[nodeX][nodeY - 1];
+													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x8) == 0)) {
 														continue;
 													}
 												}
-												if (local21 >= anInt4539 && local21 < LightingManager.anInt4866 - 1) {
-													local153 = local31[local18][local21 + 1];
-													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (local8.allInteriorFlags & 0x2) == 0)) {
+												if (nodeY >= cameraTileZ && nodeY < LightingManager.anInt4866 - 1) {
+													local153 = levelTiles[nodeX][nodeY + 1];
+													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x2) == 0)) {
 														continue;
 													}
 												}
 											} else {
 												arg1 = true;
 											}
-											local8.aBoolean45 = false;
-											if (local8.aClass3_Sub5_1 != null) {
-												local153 = local8.aClass3_Sub5_1;
+											node.aBoolean45 = false;
+											if (node.aClass3_Sub5_1 != null) {
+												local153 = node.aClass3_Sub5_1;
 												if (GlRenderer.enabled) {
-													GlRenderer.method4159(201.5F - (float) (local153.anInt668 + 1) * 50.0F);
+													GlRenderer.method4159(201.5F - (float) (local153.plane + 1) * 50.0F);
 												}
 												if (local153.plainTile == null) {
 													if (local153.shapedTile != null) {
-														method2762(local153.shapedTile, anInt2886, anInt3038, anInt5205, anInt2222, local18, local21, method187(0, local18, local21));
+														method2762(local153.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, method187(0, nodeX, nodeY));
 													}
 												} else
-													method2610(local153.plainTile, 0, anInt2886, anInt3038, anInt5205, anInt2222, local18, local21, method187(0, local18, local21));
+													method2610(local153.plainTile, 0, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, method187(0, nodeX, nodeY));
 												var22 = local153.wall;
 												if (var22 != null) {
 													if (GlRenderer.enabled) {
-														if ((var22.anInt3049 & local8.anInt670) == 0) {
-															LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+														if ((var22.anInt3049 & node.anInt670) == 0) {
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 														} else {
-															LightingManager.method2388(var22.anInt3049, anInt3555, anInt3947, anInt4903, local27, local18, local21);
+															LightingManager.method2388(var22.anInt3049, cameraX, cameraY, cameraZ, plane, nodeX, nodeY);
 														}
 													}
-													var22.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, var22.xFine - anInt3555, var22.anInt3051 - anInt3947, var22.zFine - anInt4903, var22.key, local24, null);
+													var22.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, var22.xFine - cameraX, var22.anInt3051 - cameraY, var22.zFine - cameraZ, var22.key, level, null);
 												}
-												for (local65 = 0; local65 < local153.sceneryLen; local65++) {
-													var25 = local153.scenery[local65];
-													if (var25 != null) {
+												for (sceneryIndex = 0; sceneryIndex < local153.sceneryLen; sceneryIndex++) {
+													scenery = local153.scenery[sceneryIndex];
+													if (scenery != null) {
 														if (GlRenderer.enabled) {
-															LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 														}
-														var25.entity.render(var25.anInt1714, anInt2886, anInt3038, anInt5205, anInt2222, var25.anInt1699 - anInt3555, var25.anInt1706 - anInt3947, var25.anInt1703 - anInt4903, var25.key, local24, null);
+														scenery.entity.render(scenery.anInt1714, pitchSin, pitchCos, yawSin, yawCos, scenery.anInt1699 - cameraX, scenery.anInt1706 - cameraY, scenery.anInt1703 - cameraZ, scenery.key, level, null);
 													}
 												}
 												if (GlRenderer.enabled) {
@@ -1773,103 +1773,103 @@ public class SceneGraph {
 												}
 											}
 											var24 = false;
-											if (local8.plainTile == null) {
-												if (local8.shapedTile != null) {
-													if (method187(local27, local18, local21)) {
-														method2762(local8.shapedTile, anInt2886, anInt3038, anInt5205, anInt2222, local18, local21, true);
+											if (node.plainTile == null) {
+												if (node.shapedTile != null) {
+													if (method187(plane, nodeX, nodeY)) {
+														method2762(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, true);
 													} else {
 														var24 = true;
-														method2762(local8.shapedTile, anInt2886, anInt3038, anInt5205, anInt2222, local18, local21, false);
+														method2762(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, false);
 													}
 												}
-											} else if (method187(local27, local18, local21)) {
-												method2610(local8.plainTile, local27, anInt2886, anInt3038, anInt5205, anInt2222, local18, local21, true);
+											} else if (method187(plane, nodeX, nodeY)) {
+												method2610(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, true);
 											} else {
 												var24 = true;
-												if (local8.plainTile.anInt4865 != 12345678 || MiniMenu.aBoolean187 && local24 <= MiniMenu.anInt3902) {
-													method2610(local8.plainTile, local27, anInt2886, anInt3038, anInt5205, anInt2222, local18, local21, false);
+												if (node.plainTile.anInt4865 != 12345678 || MiniMenu.aBoolean187 && level <= MiniMenu.anInt3902) {
+													method2610(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, false);
 												}
 											}
 											if (var24) {
-												@Pc(549) GroundDecor local549 = local8.groundDecor;
+												@Pc(549) GroundDecor local549 = node.groundDecor;
 												if (local549 != null && (local549.key & 0x80000000L) != 0L) {
 													if (GlRenderer.enabled && local549.aBoolean49) {
 														GlRenderer.method4159(local33 + 50.0F - 1.5F);
 													}
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 													}
-													local549.entity.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local549.xFine - anInt3555, local549.anInt733 - anInt3947, local549.zFine - anInt4903, local549.key, local24, null);
+													local549.entity.render(0, pitchSin, pitchCos, yawSin, yawCos, local549.xFine - cameraX, local549.anInt733 - cameraY, local549.zFine - cameraZ, local549.key, level, null);
 													if (GlRenderer.enabled && local549.aBoolean49) {
 														GlRenderer.method4159(local33);
 													}
 												}
 											}
 											var10 = 0;
-											local65 = 0;
-											@Pc(616) Wall local616 = local8.wall;
-											@Pc(619) WallDecor local619 = local8.wallDecor;
-											if (local616 != null || local619 != null) {
-												if (anInt4069 == local18) {
+											sceneryIndex = 0;
+											@Pc(616) Wall wall = node.wall;
+											@Pc(619) WallDecor wallDecor = node.wallDecor;
+											if (wall != null || wallDecor != null) {
+												if (cameraTileX == nodeX) {
 													var10++;
-												} else if (anInt4069 < local18) {
+												} else if (cameraTileX < nodeX) {
 													var10 += 2;
 												}
-												if (anInt4539 == local21) {
+												if (cameraTileZ == nodeY) {
 													var10 += 3;
-												} else if (anInt4539 > local21) {
+												} else if (cameraTileZ > nodeY) {
 													var10 += 6;
 												}
-												local65 = anIntArray324[var10];
-												local8.anInt670 = anIntArray386[var10];
+												sceneryIndex = anIntArray324[var10];
+												node.anInt670 = anIntArray386[var10];
 											}
-											if (local616 != null) {
-												if ((local616.anInt3049 & anIntArray215[var10]) == 0) {
-													local8.anInt663 = 0;
-												} else if (local616.anInt3049 == 16) {
-													local8.anInt663 = 3;
-													local8.anInt665 = anIntArray294[var10];
-													local8.anInt667 = 3 - local8.anInt665;
-												} else if (local616.anInt3049 == 32) {
-													local8.anInt663 = 6;
-													local8.anInt665 = anIntArray489[var10];
-													local8.anInt667 = 6 - local8.anInt665;
-												} else if (local616.anInt3049 == 64) {
-													local8.anInt663 = 12;
-													local8.anInt665 = anIntArray211[var10];
-													local8.anInt667 = 12 - local8.anInt665;
+											if (wall != null) {
+												if ((wall.anInt3049 & anIntArray215[var10]) == 0) {
+													node.anInt663 = 0;
+												} else if (wall.anInt3049 == 16) {
+													node.anInt663 = 3;
+													node.anInt665 = anIntArray294[var10];
+													node.anInt667 = 3 - node.anInt665;
+												} else if (wall.anInt3049 == 32) {
+													node.anInt663 = 6;
+													node.anInt665 = anIntArray489[var10];
+													node.anInt667 = 6 - node.anInt665;
+												} else if (wall.anInt3049 == 64) {
+													node.anInt663 = 12;
+													node.anInt665 = anIntArray211[var10];
+													node.anInt667 = 12 - node.anInt665;
 												} else {
-													local8.anInt663 = 9;
-													local8.anInt665 = anIntArray307[var10];
-													local8.anInt667 = 9 - local8.anInt665;
+													node.anInt663 = 9;
+													node.anInt665 = anIntArray307[var10];
+													node.anInt667 = 9 - node.anInt665;
 												}
-												if ((local616.anInt3049 & local65) != 0 && !method3850(local27, local18, local21, local616.anInt3049)) {
+												if ((wall.anInt3049 & sceneryIndex) != 0 && !method3850(plane, nodeX, nodeY, wall.anInt3049)) {
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 													}
-													local616.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local616.xFine - anInt3555, local616.anInt3051 - anInt3947, local616.zFine - anInt4903, local616.key, local24, null);
+													wall.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, wall.xFine - cameraX, wall.anInt3051 - cameraY, wall.zFine - cameraZ, wall.key, level, null);
 												}
-												if ((local616.anInt3052 & local65) != 0 && !method3850(local27, local18, local21, local616.anInt3052)) {
+												if ((wall.anInt3052 & sceneryIndex) != 0 && !method3850(plane, nodeX, nodeY, wall.anInt3052)) {
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 													}
-													local616.secondary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local616.xFine - anInt3555, local616.anInt3051 - anInt3947, local616.zFine - anInt4903, local616.key, local24, null);
+													wall.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, wall.xFine - cameraX, wall.anInt3051 - cameraY, wall.zFine - cameraZ, wall.key, level, null);
 												}
 											}
-											if (local619 != null && !method4611(local27, local18, local21, local619.primary.getMinY())) {
+											if (wallDecor != null && !method4611(plane, nodeX, nodeY, wallDecor.primary.getMinY())) {
 												if (GlRenderer.enabled) {
 													GlRenderer.method4159(local33 - 0.5F);
 												}
-												if ((local619.anInt1395 & local65) != 0) {
+												if ((wallDecor.anInt1395 & sceneryIndex) != 0) {
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 													}
-													local619.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local619.xFine + local619.xOffset - anInt3555, local619.anInt1391 - anInt3947, local619.zFine + local619.zOffset - anInt4903, local619.key, local24, null);
-												} else if (local619.anInt1395 == 256) {
-													local894 = local619.xFine - anInt3555;
-													local899 = local619.anInt1391 - anInt3947;
-													local904 = local619.zFine - anInt4903;
-													var17 = local619.anInt1388;
+													wallDecor.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, wallDecor.xFine + wallDecor.xOffset - cameraX, wallDecor.yFine - cameraY, wallDecor.zFine + wallDecor.zOffset - cameraZ, wallDecor.key, level, null);
+												} else if (wallDecor.anInt1395 == 256) {
+													local894 = wallDecor.xFine - cameraX;
+													local899 = wallDecor.yFine - cameraY;
+													local904 = wallDecor.zFine - cameraZ;
+													var17 = wallDecor.anInt1388;
 													if (var17 == 1 || var17 == 2) {
 														var18 = -local894;
 													} else {
@@ -1883,14 +1883,14 @@ public class SceneGraph {
 													}
 													if (local928 < var18) {
 														if (GlRenderer.enabled) {
-															LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 														}
-														local619.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local894 + local619.xOffset, local899, local904 + local619.zOffset, local619.key, local24, null);
-													} else if (local619.secondary != null) {
+														wallDecor.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, local894 + wallDecor.xOffset, local899, local904 + wallDecor.zOffset, wallDecor.key, level, null);
+													} else if (wallDecor.secondary != null) {
 														if (GlRenderer.enabled) {
-															LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 														}
-														local619.secondary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local894, local899, local904, local619.key, local24, null);
+														wallDecor.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, local894, local899, local904, wallDecor.key, level, null);
 													}
 												}
 												if (GlRenderer.enabled) {
@@ -1898,57 +1898,57 @@ public class SceneGraph {
 												}
 											}
 											if (var24) {
-												@Pc(1001) GroundDecor local1001 = local8.groundDecor;
+												@Pc(1001) GroundDecor local1001 = node.groundDecor;
 												if (local1001 != null && (local1001.key & 0x80000000L) == 0L) {
 													if (GlRenderer.enabled && local1001.aBoolean49) {
 														GlRenderer.method4159(local33 + 50.0F - 1.5F);
 													}
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 													}
-													local1001.entity.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local1001.xFine - anInt3555, local1001.anInt733 - anInt3947, local1001.zFine - anInt4903, local1001.key, local24, null);
+													local1001.entity.render(0, pitchSin, pitchCos, yawSin, yawCos, local1001.xFine - cameraX, local1001.anInt733 - cameraY, local1001.zFine - cameraZ, local1001.key, level, null);
 													if (GlRenderer.enabled && local1001.aBoolean49) {
 														GlRenderer.method4159(local33);
 													}
 												}
-												@Pc(1064) ObjStackEntity local1064 = local8.objStack;
-												if (local1064 != null && local1064.anInt3063 == 0) {
+												@Pc(1064) ObjStackEntity stackEntity = node.objStack;
+												if (stackEntity != null && stackEntity.minY == 0) {
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 													}
-													if (local1064.secondary != null) {
-														local1064.secondary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local1064.xFine - anInt3555, local1064.anInt3057 - anInt3947, local1064.zFine - anInt4903, local1064.key, local24, null);
+													if (stackEntity.secondary != null) {
+														stackEntity.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, stackEntity.xFine - cameraX, stackEntity.yFine - cameraY, stackEntity.zFine - cameraZ, stackEntity.key, level, null);
 													}
-													if (local1064.tertiary != null) {
-														local1064.tertiary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local1064.xFine - anInt3555, local1064.anInt3057 - anInt3947, local1064.zFine - anInt4903, local1064.key, local24, null);
+													if (stackEntity.tertiary != null) {
+														stackEntity.tertiary.render(0, pitchSin, pitchCos, yawSin, yawCos, stackEntity.xFine - cameraX, stackEntity.yFine - cameraY, stackEntity.zFine - cameraZ, stackEntity.key, level, null);
 													}
-													if (local1064.primary != null) {
-														local1064.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local1064.xFine - anInt3555, local1064.anInt3057 - anInt3947, local1064.zFine - anInt4903, local1064.key, local24, null);
+													if (stackEntity.primary != null) {
+														stackEntity.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, stackEntity.xFine - cameraX, stackEntity.yFine - cameraY, stackEntity.zFine - cameraZ, stackEntity.key, level, null);
 													}
 												}
 											}
-											local894 = local8.allInteriorFlags;
+											local894 = node.allInteriorFlags;
 											if (local894 != 0) {
-												if (local18 < anInt4069 && (local894 & 0x4) != 0) {
-													var32 = local31[local18 + 1][local21];
+												if (nodeX < cameraTileX && (local894 & 0x4) != 0) {
+													var32 = levelTiles[nodeX + 1][nodeY];
 													if (var32 != null && var32.aBoolean46) {
 														aClass69_32.addTail(var32);
 													}
 												}
-												if (local21 < anInt4539 && (local894 & 0x2) != 0) {
-													var32 = local31[local18][local21 + 1];
+												if (nodeY < cameraTileZ && (local894 & 0x2) != 0) {
+													var32 = levelTiles[nodeX][nodeY + 1];
 													if (var32 != null && var32.aBoolean46) {
 														aClass69_32.addTail(var32);
 													}
 												}
-												if (local18 > anInt4069 && (local894 & 0x1) != 0) {
-													var32 = local31[local18 - 1][local21];
+												if (nodeX > cameraTileX && (local894 & 0x1) != 0) {
+													var32 = levelTiles[nodeX - 1][nodeY];
 													if (var32 != null && var32.aBoolean46) {
 														aClass69_32.addTail(var32);
 													}
 												}
-												if (local21 > anInt4539 && (local894 & 0x8) != 0) {
-													var32 = local31[local18][local21 - 1];
+												if (nodeY > cameraTileZ && (local894 & 0x8) != 0) {
+													var32 = levelTiles[nodeX][nodeY - 1];
 													if (var32 != null && var32.aBoolean46) {
 														aClass69_32.addTail(var32);
 													}
@@ -1956,130 +1956,130 @@ public class SceneGraph {
 											}
 											break;
 										}
-										if (local8.anInt663 != 0) {
+										if (node.anInt663 != 0) {
 											var24 = true;
-											for (var10 = 0; var10 < local8.sceneryLen; var10++) {
-												if (local8.scenery[var10].anInt1707 != anInt437 && (local8.interiorFlags[var10] & local8.anInt663) == local8.anInt665) {
+											for (var10 = 0; var10 < node.sceneryLen; var10++) {
+												if (node.scenery[var10].anInt1707 != anInt437 && (node.interiorFlags[var10] & node.anInt663) == node.anInt665) {
 													var24 = false;
 													break;
 												}
 											}
 											if (var24) {
-												var22 = local8.wall;
-												if (!method3850(local27, local18, local21, var22.anInt3049)) {
+												var22 = node.wall;
+												if (!method3850(plane, nodeX, nodeY, var22.anInt3049)) {
 													if (GlRenderer.enabled) {
 														label882:
 														{
 															if ((var22.key & 0xFC000L) == 16384L) {
-																local65 = var22.xFine - anInt3555;
-																local115 = var22.zFine - anInt4903;
+																sceneryIndex = var22.xFine - cameraX;
+																local115 = var22.zFine - cameraZ;
 																local1332 = (int) (var22.key >> 20 & 0x3L);
 																if (local1332 == 0) {
-																	local65 -= 64;
+																	sceneryIndex -= 64;
 																	local115 += 64;
-																	if (local115 < local65 && local18 > 0 && local21 < length - 1) {
-																		LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18 - 1, local21 + 1);
+																	if (local115 < sceneryIndex && nodeX > 0 && nodeY < length - 1) {
+																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX - 1, nodeY + 1);
 																		break label882;
 																	}
 																} else if (local1332 == 1) {
-																	local65 += 64;
+																	sceneryIndex += 64;
 																	local115 += 64;
-																	if (local115 < -local65 && local18 < width - 1 && local21 < length - 1) {
-																		LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18 + 1, local21 + 1);
+																	if (local115 < -sceneryIndex && nodeX < width - 1 && nodeY < length - 1) {
+																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX + 1, nodeY + 1);
 																		break label882;
 																	}
 																} else if (local1332 == 2) {
-																	local65 += 64;
+																	sceneryIndex += 64;
 																	local115 -= 64;
-																	if (local115 > local65 && local18 < width - 1 && local21 > 0) {
-																		LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18 + 1, local21 - 1);
+																	if (local115 > sceneryIndex && nodeX < width - 1 && nodeY > 0) {
+																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX + 1, nodeY - 1);
 																		break label882;
 																	}
 																} else if (local1332 == 3) {
-																	local65 -= 64;
+																	sceneryIndex -= 64;
 																	local115 -= 64;
-																	if (local115 > -local65 && local18 > 0 && local21 > 0) {
-																		LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18 - 1, local21 - 1);
+																	if (local115 > -sceneryIndex && nodeX > 0 && nodeY > 0) {
+																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX - 1, nodeY - 1);
 																		break label882;
 																	}
 																}
 															}
-															LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 														}
 													}
-													var22.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, var22.xFine - anInt3555, var22.anInt3051 - anInt3947, var22.zFine - anInt4903, var22.key, local24, null);
+													var22.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, var22.xFine - cameraX, var22.anInt3051 - cameraY, var22.zFine - cameraZ, var22.key, level, null);
 												}
-												local8.anInt663 = 0;
+												node.anInt663 = 0;
 											}
 										}
-										if (!local8.aBoolean47) {
+										if (!node.aBoolean47) {
 											break;
 										}
 										try {
-											var9 = local8.sceneryLen;
-											local8.aBoolean47 = false;
+											sceneryLength = node.sceneryLen;
+											node.aBoolean47 = false;
 											var10 = 0;
 											label767:
-											for (local65 = 0; local65 < var9; local65++) {
-												var25 = local8.scenery[local65];
-												if (var25.anInt1707 != anInt437) {
-													for (local1332 = var25.xMin; local1332 <= var25.xMax; local1332++) {
-														for (local894 = var25.zMin; local894 <= var25.zMax; local894++) {
-															var32 = local31[local1332][local894];
+											for (sceneryIndex = 0; sceneryIndex < sceneryLength; sceneryIndex++) {
+												scenery = node.scenery[sceneryIndex];
+												if (scenery.anInt1707 != anInt437) {
+													for (local1332 = scenery.xMin; local1332 <= scenery.xMax; local1332++) {
+														for (local894 = scenery.zMin; local894 <= scenery.zMax; local894++) {
+															var32 = levelTiles[local1332][local894];
 															if (var32.aBoolean45) {
-																local8.aBoolean47 = true;
+																node.aBoolean47 = true;
 																continue label767;
 															}
 															if (var32.anInt663 != 0) {
 																local904 = 0;
-																if (local1332 > var25.xMin) {
+																if (local1332 > scenery.xMin) {
 																	local904++;
 																}
-																if (local1332 < var25.xMax) {
+																if (local1332 < scenery.xMax) {
 																	local904 += 4;
 																}
-																if (local894 > var25.zMin) {
+																if (local894 > scenery.zMin) {
 																	local904 += 8;
 																}
-																if (local894 < var25.zMax) {
+																if (local894 < scenery.zMax) {
 																	local904 += 2;
 																}
-																if ((local904 & var32.anInt663) == local8.anInt667) {
-																	local8.aBoolean47 = true;
+																if ((local904 & var32.anInt663) == node.anInt667) {
+																	node.aBoolean47 = true;
 																	continue label767;
 																}
 															}
 														}
 													}
-													aClass31Array2[var10++] = var25;
-													local1332 = anInt4069 - var25.xMin;
-													local894 = var25.xMax - anInt4069;
+													aClass31Array2[var10++] = scenery;
+													local1332 = cameraTileX - scenery.xMin;
+													local894 = scenery.xMax - cameraTileX;
 													if (local894 > local1332) {
 														local1332 = local894;
 													}
-													local899 = anInt4539 - var25.zMin;
-													local904 = var25.zMax - anInt4539;
+													local899 = cameraTileZ - scenery.zMin;
+													local904 = scenery.zMax - cameraTileZ;
 													if (local904 > local899) {
-														var25.anInt1705 = local1332 + local904;
+														scenery.anInt1705 = local1332 + local904;
 													} else {
-														var25.anInt1705 = local1332 + local899;
+														scenery.anInt1705 = local1332 + local899;
 													}
 												}
 											}
 											while (var10 > 0) {
-												local65 = -50;
+												sceneryIndex = -50;
 												local115 = -1;
 												for (local1332 = 0; local1332 < var10; local1332++) {
 													@Pc(1628) Scenery local1628 = aClass31Array2[local1332];
 													if (local1628.anInt1707 != anInt437) {
-														if (local1628.anInt1705 > local65) {
-															local65 = local1628.anInt1705;
+														if (local1628.anInt1705 > sceneryIndex) {
+															sceneryIndex = local1628.anInt1705;
 															local115 = local1332;
-														} else if (local1628.anInt1705 == local65) {
-															local899 = local1628.anInt1699 - anInt3555;
-															local904 = local1628.anInt1703 - anInt4903;
-															var17 = aClass31Array2[local115].anInt1699 - anInt3555;
-															var18 = aClass31Array2[local115].anInt1703 - anInt4903;
+														} else if (local1628.anInt1705 == sceneryIndex) {
+															local899 = local1628.anInt1699 - cameraX;
+															local904 = local1628.anInt1703 - cameraZ;
+															var17 = aClass31Array2[local115].anInt1699 - cameraX;
+															var18 = aClass31Array2[local115].anInt1703 - cameraZ;
 															if (local899 * local899 + local904 * local904 > var17 * var17 + var18 * var18) {
 																local115 = local1332;
 															}
@@ -2091,105 +2091,105 @@ public class SceneGraph {
 												}
 												@Pc(1697) Scenery local1697 = aClass31Array2[local115];
 												local1697.anInt1707 = anInt437;
-												if (!method1599(local27, local1697.xMin, local1697.xMax, local1697.zMin, local1697.zMax, local1697.entity.getMinY())) {
+												if (!method1599(plane, local1697.xMin, local1697.xMax, local1697.zMin, local1697.zMax, local1697.entity.getMinY())) {
 													if (GlRenderer.enabled) {
 														if ((local1697.key & 0xFC000L) == 147456L) {
-															LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
-															local894 = local1697.anInt1699 - anInt3555;
-															local899 = local1697.anInt1703 - anInt4903;
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+															local894 = local1697.anInt1699 - cameraX;
+															local899 = local1697.anInt1703 - cameraZ;
 															local904 = (int) (local1697.key >> 20 & 0x3L);
 															if (local904 == 1 || local904 == 3) {
 																if (local899 > -local894) {
-																	LightingManager.method2397(local24, local18, local21 - 1, local18 - 1, local21);
+																	LightingManager.method2397(level, nodeX, nodeY - 1, nodeX - 1, nodeY);
 																} else {
-																	LightingManager.method2397(local24, local18, local21 + 1, local18 + 1, local21);
+																	LightingManager.method2397(level, nodeX, nodeY + 1, nodeX + 1, nodeY);
 																}
 															} else if (local899 > local894) {
-																LightingManager.method2397(local24, local18, local21 - 1, local18 + 1, local21);
+																LightingManager.method2397(level, nodeX, nodeY - 1, nodeX + 1, nodeY);
 															} else {
-																LightingManager.method2397(local24, local18, local21 + 1, local18 - 1, local21);
+																LightingManager.method2397(level, nodeX, nodeY + 1, nodeX - 1, nodeY);
 															}
 														} else {
-															LightingManager.method2391(anInt3555, anInt3947, anInt4903, local24, local1697.xMin, local1697.zMin, local1697.xMax, local1697.zMax);
+															LightingManager.method2391(cameraX, cameraY, cameraZ, level, local1697.xMin, local1697.zMin, local1697.xMax, local1697.zMax);
 														}
 													}
-													local1697.entity.render(local1697.anInt1714, anInt2886, anInt3038, anInt5205, anInt2222, local1697.anInt1699 - anInt3555, local1697.anInt1706 - anInt3947, local1697.anInt1703 - anInt4903, local1697.key, local24, null);
+													local1697.entity.render(local1697.anInt1714, pitchSin, pitchCos, yawSin, yawCos, local1697.anInt1699 - cameraX, local1697.anInt1706 - cameraY, local1697.anInt1703 - cameraZ, local1697.key, level, null);
 												}
 												for (local894 = local1697.xMin; local894 <= local1697.xMax; local894++) {
 													for (local899 = local1697.zMin; local899 <= local1697.zMax; local899++) {
-														@Pc(1863) Tile local1863 = local31[local894][local899];
+														@Pc(1863) Tile local1863 = levelTiles[local894][local899];
 														if (local1863.anInt663 != 0) {
 															aClass69_32.addTail(local1863);
-														} else if ((local894 != local18 || local899 != local21) && local1863.aBoolean46) {
+														} else if ((local894 != nodeX || local899 != nodeY) && local1863.aBoolean46) {
 															aClass69_32.addTail(local1863);
 														}
 													}
 												}
 											}
-											if (!local8.aBoolean47) {
+											if (!node.aBoolean47) {
 												break;
 											}
 										} catch (@Pc(1895) Exception local1895) {
-											local8.aBoolean47 = false;
+											node.aBoolean47 = false;
 											break;
 										}
 									}
-								} while (!local8.aBoolean46);
-							} while (local8.anInt663 != 0);
-							if (local18 > anInt4069 || local18 <= LightingManager.anInt987) {
+								} while (!node.aBoolean46);
+							} while (node.anInt663 != 0);
+							if (nodeX > cameraTileX || nodeX <= LightingManager.anInt987) {
 								break;
 							}
-							local153 = local31[local18 - 1][local21];
+							local153 = levelTiles[nodeX - 1][nodeY];
 						} while (local153 != null && local153.aBoolean46);
-						if (local18 < anInt4069 || local18 >= LightingManager.anInt15 - 1) {
+						if (nodeX < cameraTileX || nodeX >= LightingManager.anInt15 - 1) {
 							break;
 						}
-						local153 = local31[local18 + 1][local21];
+						local153 = levelTiles[nodeX + 1][nodeY];
 					} while (local153 != null && local153.aBoolean46);
-					if (local21 > anInt4539 || local21 <= LightingManager.anInt4698) {
+					if (nodeY > cameraTileZ || nodeY <= LightingManager.anInt4698) {
 						break;
 					}
-					local153 = local31[local18][local21 - 1];
+					local153 = levelTiles[nodeX][nodeY - 1];
 				} while (local153 != null && local153.aBoolean46);
-				if (local21 < anInt4539 || local21 >= LightingManager.anInt4866 - 1) {
+				if (nodeY < cameraTileZ || nodeY >= LightingManager.anInt4866 - 1) {
 					break;
 				}
-				local153 = local31[local18][local21 + 1];
+				local153 = levelTiles[nodeX][nodeY + 1];
 			} while (local153 != null && local153.aBoolean46);
-			local8.aBoolean46 = false;
+			node.aBoolean46 = false;
 			anInt1142--;
-			@Pc(1999) ObjStackEntity local1999 = local8.objStack;
-			if (local1999 != null && local1999.anInt3063 != 0) {
+			@Pc(1999) ObjStackEntity stackEntity = node.objStack;
+			if (stackEntity != null && stackEntity.minY != 0) {
 				if (GlRenderer.enabled) {
-					LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+					LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 				}
-				if (local1999.secondary != null) {
-					local1999.secondary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local1999.xFine - anInt3555, local1999.anInt3057 - anInt3947 - local1999.anInt3063, local1999.zFine - anInt4903, local1999.key, local24, null);
+				if (stackEntity.secondary != null) {
+					stackEntity.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, stackEntity.xFine - cameraX, stackEntity.yFine - cameraY - stackEntity.minY, stackEntity.zFine - cameraZ, stackEntity.key, level, null);
 				}
-				if (local1999.tertiary != null) {
-					local1999.tertiary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local1999.xFine - anInt3555, local1999.anInt3057 - anInt3947 - local1999.anInt3063, local1999.zFine - anInt4903, local1999.key, local24, null);
+				if (stackEntity.tertiary != null) {
+					stackEntity.tertiary.render(0, pitchSin, pitchCos, yawSin, yawCos, stackEntity.xFine - cameraX, stackEntity.yFine - cameraY - stackEntity.minY, stackEntity.zFine - cameraZ, stackEntity.key, level, null);
 				}
-				if (local1999.primary != null) {
-					local1999.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local1999.xFine - anInt3555, local1999.anInt3057 - anInt3947 - local1999.anInt3063, local1999.zFine - anInt4903, local1999.key, local24, null);
+				if (stackEntity.primary != null) {
+					stackEntity.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, stackEntity.xFine - cameraX, stackEntity.yFine - cameraY - stackEntity.minY, stackEntity.zFine - cameraZ, stackEntity.key, level, null);
 				}
 			}
-			if (local8.anInt670 != 0) {
-				@Pc(2109) WallDecor local2109 = local8.wallDecor;
-				if (local2109 != null && !method4611(local27, local18, local21, local2109.primary.getMinY())) {
-					if ((local2109.anInt1395 & local8.anInt670) != 0) {
+			if (node.anInt670 != 0) {
+				@Pc(2109) WallDecor wallDecor = node.wallDecor;
+				if (wallDecor != null && !method4611(plane, nodeX, nodeY, wallDecor.primary.getMinY())) {
+					if ((wallDecor.anInt1395 & node.anInt670) != 0) {
 						if (GlRenderer.enabled) {
-							LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+							LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 						}
-						local2109.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local2109.xFine + local2109.xOffset - anInt3555, local2109.anInt1391 - anInt3947, local2109.zFine + local2109.zOffset - anInt4903, local2109.key, local24, null);
-					} else if (local2109.anInt1395 == 256) {
-						local65 = local2109.xFine - anInt3555;
-						local115 = local2109.anInt1391 - anInt3947;
-						local1332 = local2109.zFine - anInt4903;
-						local894 = local2109.anInt1388;
+						wallDecor.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, wallDecor.xFine + wallDecor.xOffset - cameraX, wallDecor.yFine - cameraY, wallDecor.zFine + wallDecor.zOffset - cameraZ, wallDecor.key, level, null);
+					} else if (wallDecor.anInt1395 == 256) {
+						sceneryIndex = wallDecor.xFine - cameraX;
+						local115 = wallDecor.yFine - cameraY;
+						local1332 = wallDecor.zFine - cameraZ;
+						local894 = wallDecor.anInt1388;
 						if (local894 == 1 || local894 == 2) {
-							local899 = -local65;
+							local899 = -sceneryIndex;
 						} else {
-							local899 = local65;
+							local899 = sceneryIndex;
 						}
 						if (local894 == 2 || local894 == 3) {
 							local904 = -local1332;
@@ -2198,62 +2198,62 @@ public class SceneGraph {
 						}
 						if (local904 >= local899) {
 							if (GlRenderer.enabled) {
-								LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+								LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 							}
-							local2109.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local65 + local2109.xOffset, local115, local1332 + local2109.zOffset, local2109.key, local24, null);
-						} else if (local2109.secondary != null) {
+							wallDecor.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, sceneryIndex + wallDecor.xOffset, local115, local1332 + wallDecor.zOffset, wallDecor.key, level, null);
+						} else if (wallDecor.secondary != null) {
 							if (GlRenderer.enabled) {
-								LightingManager.method2393(anInt3555, anInt3947, anInt4903, local24, local18, local21);
+								LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
 							}
-							local2109.secondary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local65, local115, local1332, local2109.key, local24, null);
+							wallDecor.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, sceneryIndex, local115, local1332, wallDecor.key, level, null);
 						}
 					}
 				}
-				@Pc(2275) Wall local2275 = local8.wall;
+				@Pc(2275) Wall local2275 = node.wall;
 				if (local2275 != null) {
-					if ((local2275.anInt3052 & local8.anInt670) != 0 && !method3850(local27, local18, local21, local2275.anInt3052)) {
+					if ((local2275.anInt3052 & node.anInt670) != 0 && !method3850(plane, nodeX, nodeY, local2275.anInt3052)) {
 						if (GlRenderer.enabled) {
-							LightingManager.method2388(local2275.anInt3052, anInt3555, anInt3947, anInt4903, local27, local18, local21);
+							LightingManager.method2388(local2275.anInt3052, cameraX, cameraY, cameraZ, plane, nodeX, nodeY);
 						}
-						local2275.secondary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local2275.xFine - anInt3555, local2275.anInt3051 - anInt3947, local2275.zFine - anInt4903, local2275.key, local24, null);
+						local2275.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, local2275.xFine - cameraX, local2275.anInt3051 - cameraY, local2275.zFine - cameraZ, local2275.key, level, null);
 					}
-					if ((local2275.anInt3049 & local8.anInt670) != 0 && !method3850(local27, local18, local21, local2275.anInt3049)) {
+					if ((local2275.anInt3049 & node.anInt670) != 0 && !method3850(plane, nodeX, nodeY, local2275.anInt3049)) {
 						if (GlRenderer.enabled) {
-							LightingManager.method2388(local2275.anInt3049, anInt3555, anInt3947, anInt4903, local27, local18, local21);
+							LightingManager.method2388(local2275.anInt3049, cameraX, cameraY, cameraZ, plane, nodeX, nodeY);
 						}
-						local2275.primary.render(0, anInt2886, anInt3038, anInt5205, anInt2222, local2275.xFine - anInt3555, local2275.anInt3051 - anInt3947, local2275.zFine - anInt4903, local2275.key, local24, null);
+						local2275.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, local2275.xFine - cameraX, local2275.anInt3051 - cameraY, local2275.zFine - cameraZ, local2275.key, level, null);
 					}
 				}
 			}
-			@Pc(2388) Tile local2388;
-			if (local24 < levels - 1) {
-				local2388 = tiles[local24 + 1][local18][local21];
-				if (local2388 != null && local2388.aBoolean46) {
-					aClass69_32.addTail(local2388);
+			@Pc(2388) Tile nextLevelTile;
+			if (level < levels - 1) {
+				nextLevelTile = tiles[level + 1][nodeX][nodeY];
+				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
+					aClass69_32.addTail(nextLevelTile);
 				}
 			}
-			if (local18 < anInt4069) {
-				local2388 = local31[local18 + 1][local21];
-				if (local2388 != null && local2388.aBoolean46) {
-					aClass69_32.addTail(local2388);
+			if (nodeX < cameraTileX) {
+				nextLevelTile = levelTiles[nodeX + 1][nodeY];
+				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
+					aClass69_32.addTail(nextLevelTile);
 				}
 			}
-			if (local21 < anInt4539) {
-				local2388 = local31[local18][local21 + 1];
-				if (local2388 != null && local2388.aBoolean46) {
-					aClass69_32.addTail(local2388);
+			if (nodeY < cameraTileZ) {
+				nextLevelTile = levelTiles[nodeX][nodeY + 1];
+				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
+					aClass69_32.addTail(nextLevelTile);
 				}
 			}
-			if (local18 > anInt4069) {
-				local2388 = local31[local18 - 1][local21];
-				if (local2388 != null && local2388.aBoolean46) {
-					aClass69_32.addTail(local2388);
+			if (nodeX > cameraTileX) {
+				nextLevelTile = levelTiles[nodeX - 1][nodeY];
+				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
+					aClass69_32.addTail(nextLevelTile);
 				}
 			}
-			if (local21 > anInt4539) {
-				local2388 = local31[local18][local21 - 1];
-				if (local2388 != null && local2388.aBoolean46) {
-					aClass69_32.addTail(local2388);
+			if (nodeY > cameraTileZ) {
+				nextLevelTile = levelTiles[nodeX][nodeY - 1];
+				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
+					aClass69_32.addTail(nextLevelTile);
 				}
 			}
 		}
@@ -2283,7 +2283,7 @@ public class SceneGraph {
 		@Pc(36) int local36 = local24 - 238;
 		if (arg3 < 16) {
 			if (arg3 == 1) {
-				if (local10 > anInt3555) {
+				if (local10 > cameraX) {
 					if (!method4394(local10, local24, local14)) {
 						return false;
 					}
@@ -2305,7 +2305,7 @@ public class SceneGraph {
 				return method4394(local10, local32, local14 + 128);
 			}
 			if (arg3 == 2) {
-				if (local14 < anInt4903) {
+				if (local14 < cameraZ) {
 					if (!method4394(local10, local24, local14 + 128)) {
 						return false;
 					}
@@ -2327,7 +2327,7 @@ public class SceneGraph {
 				return method4394(local10 + 128, local32, local14 + 128);
 			}
 			if (arg3 == 4) {
-				if (local10 < anInt3555) {
+				if (local10 < cameraX) {
 					if (!method4394(local10 + 128, local24, local14)) {
 						return false;
 					}
@@ -2349,7 +2349,7 @@ public class SceneGraph {
 				return method4394(local10 + 128, local32, local14 + 128);
 			}
 			if (arg3 == 8) {
-				if (local14 > anInt4903) {
+				if (local14 > cameraZ) {
 					if (!method4394(local10, local24, local14)) {
 						return false;
 					}
@@ -2388,14 +2388,14 @@ public class SceneGraph {
 
 	@OriginalMember(owner = "client!p", name = "a", descriptor = "(IZIZLclient!mj;IIIBII)V")
 	public static void addLoc(@OriginalArg(0) int currentPlane, @OriginalArg(1) boolean lowmem, @OriginalArg(2) int plane, @OriginalArg(3) boolean highmem, @OriginalArg(4) CollisionMap map, @OriginalArg(5) int locIndex, @OriginalArg(6) int locType, @OriginalArg(7) int x, @OriginalArg(9) int z, @OriginalArg(10) int orientation) {
-		if (lowmem && !allLevelsAreVisible() && (renderFlags[0][x][z] & 0x2) == 0) {
-			if ((renderFlags[plane][x][z] & 0x10) != 0 || getRenderLevel(z, x, plane) != centralPlane) {
+		if (lowmem && !allLevelsAreVisible() && (tileRenderFlags[0][x][z] & 0x2) == 0) {
+			if ((tileRenderFlags[plane][x][z] & 0x10) != 0 || getRenderLevel(z, x, plane) != centralPlane) {
 				return;
 			}
 		}
 
-		if (plane < firstVisibleLevel) {
-			firstVisibleLevel = plane;
+		if (plane < lastVisibleLevel) {
+			lastVisibleLevel = plane;
 		}
 
 		@Pc(62) LocType loc = LocTypeList.get(locIndex);
@@ -2810,7 +2810,7 @@ public class SceneGraph {
 			LoginManager.method2463(Player.plane, centralZoneZ, centralZoneX, PlayerList.self.movementQueueZ[0], false, PlayerList.self.movementQueueX[0]);
 		} else if (Player.plane != LightingManager.anInt2875 && MiniMap.renderMap(Player.plane)) {
 			LightingManager.anInt2875 = Player.plane;
-			ScriptRunner.method2218();
+			ScriptRunner.setUpRemoveRoofTiles();
 		}
 	}
 
@@ -2849,7 +2849,7 @@ public class SceneGraph {
 					if (!highmem) {
 						@Pc(95) int markingPlane = plane;
 						// might be used with bridges?
-						if ((renderFlags[1][tileX][tileZ] & 0x2) == 2) {
+						if ((tileRenderFlags[1][tileX][tileZ] & 0x2) == 2) {
 							markingPlane--;
 						}
 						if (markingPlane >= 0) {
@@ -2893,39 +2893,39 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!mf", name = "a", descriptor = "(IIIII[[[B[I[I[I[I[IIBII)V")
-	public static void method2954(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) byte[][][] arg5, @OriginalArg(6) int[] arg6, @OriginalArg(7) int[] arg7, @OriginalArg(8) int[] arg8, @OriginalArg(9) int[] arg9, @OriginalArg(10) int[] arg10, @OriginalArg(11) int arg11, @OriginalArg(12) byte arg12, @OriginalArg(13) int arg13, @OriginalArg(14) int arg14) {
-		if (arg0 < 0) {
-			arg0 = 0;
-		} else if (arg0 >= width * 128) {
-			arg0 = width * 128 - 1;
+	public static void method2954(@OriginalArg(0) int renderX, @OriginalArg(1) int renderY, @OriginalArg(2) int renderZ, @OriginalArg(3) int cameraPitch, @OriginalArg(4) int cameraYaw, @OriginalArg(5) byte[][][] arg5, @OriginalArg(6) int[] arg6, @OriginalArg(7) int[] arg7, @OriginalArg(8) int[] arg8, @OriginalArg(9) int[] arg9, @OriginalArg(10) int[] arg10, @OriginalArg(11) int level, @OriginalArg(12) byte arg12, @OriginalArg(13) int centerX, @OriginalArg(14) int centerZ) {
+		if (renderX < 0) {
+			renderX = 0;
+		} else if (renderX >= width * 128) {
+			renderX = width * 128 - 1;
 		}
-		if (arg2 < 0) {
-			arg2 = 0;
-		} else if (arg2 >= length * 128) {
-			arg2 = length * 128 - 1;
+		if (renderZ < 0) {
+			renderZ = 0;
+		} else if (renderZ >= length * 128) {
+			renderZ = length * 128 - 1;
 		}
-		anInt2886 = MathUtils.sin[arg3];
-		anInt3038 = MathUtils.cos[arg3];
-		anInt5205 = MathUtils.sin[arg4];
-		anInt2222 = MathUtils.cos[arg4];
-		anInt3555 = arg0;
-		anInt3947 = arg1;
-		anInt4903 = arg2;
-		anInt4069 = arg0 / 128;
-		anInt4539 = arg2 / 128;
-		LightingManager.anInt987 = anInt4069 - visibility;
+		pitchSin = MathUtils.sin[cameraPitch];
+		pitchCos = MathUtils.cos[cameraPitch];
+		yawSin = MathUtils.sin[cameraYaw];
+		yawCos = MathUtils.cos[cameraYaw];
+		cameraX = renderX;
+		cameraY = renderY;
+		cameraZ = renderZ;
+		cameraTileX = renderX / 128;
+		cameraTileZ = renderZ / 128;
+		LightingManager.anInt987 = cameraTileX - visibility;
 		if (LightingManager.anInt987 < 0) {
 			LightingManager.anInt987 = 0;
 		}
-		LightingManager.anInt4698 = anInt4539 - visibility;
+		LightingManager.anInt4698 = cameraTileZ - visibility;
 		if (LightingManager.anInt4698 < 0) {
 			LightingManager.anInt4698 = 0;
 		}
-		LightingManager.anInt15 = anInt4069 + visibility;
+		LightingManager.anInt15 = cameraTileX + visibility;
 		if (LightingManager.anInt15 > width) {
 			LightingManager.anInt15 = width;
 		}
-		LightingManager.anInt4866 = anInt4539 + visibility;
+		LightingManager.anInt4866 = cameraTileZ + visibility;
 		if (LightingManager.anInt4866 > length) {
 			LightingManager.anInt4866 = length;
 		}
@@ -2939,18 +2939,18 @@ public class SceneGraph {
 		@Pc(113) int local113;
 		for (local104 = 0; local104 < visibility + visibility + 2; local104++) {
 			for (local113 = 0; local113 < visibility + visibility + 2; local113++) {
-				@Pc(130) int local130 = (local104 - visibility << 7) - (anInt3555 & 0x7F);
-				@Pc(140) int local140 = (local113 - visibility << 7) - (anInt4903 & 0x7F);
-				@Pc(146) int local146 = anInt4069 + local104 - visibility;
-				@Pc(152) int local152 = anInt4539 + local113 - visibility;
+				@Pc(130) int local130 = (local104 - visibility << 7) - (cameraX & 0x7F);
+				@Pc(140) int local140 = (local113 - visibility << 7) - (cameraZ & 0x7F);
+				@Pc(146) int local146 = cameraTileX + local104 - visibility;
+				@Pc(152) int local152 = cameraTileZ + local113 - visibility;
 				if (local146 >= 0 && local152 >= 0 && local146 < width && local152 < length) {
 					@Pc(176) int local176;
 					if (underwaterTileHeights == null) {
-						local176 = surfaceTileHeights[0][local146][local152] + 128 - anInt3947;
+						local176 = surfaceTileHeights[0][local146][local152] + 128 - cameraY;
 					} else {
-						local176 = underwaterTileHeights[0][local146][local152] + 128 - anInt3947;
+						local176 = underwaterTileHeights[0][local146][local152] + 128 - cameraY;
 					}
-					@Pc(201) int local201 = surfaceTileHeights[3][local146][local152] - anInt3947 - 1000;
+					@Pc(201) int local201 = surfaceTileHeights[3][local146][local152] - cameraY - 1000;
 					aBooleanArrayArray3[local104][local113] = method3049(local130, local201, local176, local140, local99);
 				} else {
 					aBooleanArrayArray3[local104][local113] = false;
@@ -2970,7 +2970,7 @@ public class SceneGraph {
 		method2419();
 		if (underWaterGroundTiles != null) {
 			setUnderwater(true);
-			method3292(arg0, arg1, arg2, null, 0, (byte) 0, arg13, arg14);
+			method3292(renderX, renderY, renderZ, null, 0, (byte) 0, centerX, centerZ);
 			if (GlRenderer.enabled) {
 				MaterialManager.renderingUnderwater = false;
 				MaterialManager.setMaterial(0, 0);
@@ -2979,27 +2979,27 @@ public class SceneGraph {
 			}
 			setUnderwater(false);
 		}
-		method3292(arg0, arg1, arg2, arg5, arg11, arg12, arg13, arg14);
+		method3292(renderX, renderY, renderZ, arg5, level, arg12, centerX, centerZ);
 	}
 
 	@OriginalMember(owner = "client!uc", name = "a", descriptor = "(III[[[BIBII)V")
-	public static void method3292(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) byte[][][] arg3, @OriginalArg(4) int arg4, @OriginalArg(5) byte arg5, @OriginalArg(6) int arg6, @OriginalArg(7) int arg7) {
+	public static void method3292(@OriginalArg(0) int renderX, @OriginalArg(1) int renderY, @OriginalArg(2) int renderZ, @OriginalArg(3) byte[][][] arg3, @OriginalArg(4) int arg4, @OriginalArg(5) byte arg5, @OriginalArg(6) int centerX, @OriginalArg(7) int centerZ) {
 		anInt437++;
 		anInt1142 = 0;
-		@Pc(9) int local9 = arg6 - 16;
-		@Pc(13) int local13 = arg6 + 16;
-		@Pc(17) int local17 = arg7 - 16;
-		@Pc(21) int local21 = arg7 + 16;
-		@Pc(32) int local32;
-		@Pc(37) int local37;
+		@Pc(9) int local9 = centerX - 16;
+		@Pc(13) int local13 = centerX + 16;
+		@Pc(17) int local17 = centerZ - 16;
+		@Pc(21) int local21 = centerZ + 16;
+		@Pc(32) int x;
+		@Pc(37) int z;
 		@Pc(183) int local183;
-		for (@Pc(23) int local23 = anInt5276; local23 < levels; local23++) {
-			@Pc(30) Tile[][] local30 = tiles[local23];
-			for (local32 = LightingManager.anInt987; local32 < LightingManager.anInt15; local32++) {
-				for (local37 = LightingManager.anInt4698; local37 < LightingManager.anInt4866; local37++) {
-					@Pc(46) Tile local46 = local30[local32][local37];
+		for (@Pc(23) int level = firstVisibleLevel; level < levels; level++) {
+			@Pc(30) Tile[][] levelTiles = tiles[level];
+			for (x = LightingManager.anInt987; x < LightingManager.anInt15; x++) {
+				for (z = LightingManager.anInt4698; z < LightingManager.anInt4866; z++) {
+					@Pc(46) Tile local46 = levelTiles[x][z];
 					if (local46 != null) {
-						if (aBooleanArrayArray1[local32 + visibility - anInt4069][local37 + visibility - anInt4539] && (arg3 == null || local23 < arg4 || arg3[local23][local32][local37] != arg5)) {
+						if (aBooleanArrayArray1[x + visibility - cameraTileX][z + visibility - cameraTileZ] && (arg3 == null || level < arg4 || arg3[level][x][z] != arg5)) {
 							local46.aBoolean45 = true;
 							local46.aBoolean46 = true;
 							local46.aBoolean47 = local46.sceneryLen > 0;
@@ -3008,29 +3008,29 @@ public class SceneGraph {
 							local46.aBoolean45 = false;
 							local46.aBoolean46 = false;
 							local46.anInt663 = 0;
-							if (local32 >= local9 && local32 <= local13 && local37 >= local17 && local37 <= local21) {
+							if (x >= local9 && x <= local13 && z >= local17 && z <= local21) {
 								if (local46.wall != null) {
 									@Pc(103) Wall local103 = local46.wall;
-									local103.primary.method4545(0, local23, local103.anInt3051, local103.xFine, local103.zFine);
+									local103.primary.method4545(0, level, local103.anInt3051, local103.xFine, local103.zFine);
 									if (local103.secondary != null) {
-										local103.secondary.method4545(0, local23, local103.anInt3051, local103.xFine, local103.zFine);
+										local103.secondary.method4545(0, level, local103.anInt3051, local103.xFine, local103.zFine);
 									}
 								}
 								if (local46.wallDecor != null) {
 									@Pc(134) WallDecor local134 = local46.wallDecor;
-									local134.primary.method4545(local134.anInt1388, local23, local134.anInt1391, local134.xFine, local134.zFine);
+									local134.primary.method4545(local134.anInt1388, level, local134.yFine, local134.xFine, local134.zFine);
 									if (local134.secondary != null) {
-										local134.secondary.method4545(local134.anInt1388, local23, local134.anInt1391, local134.xFine, local134.zFine);
+										local134.secondary.method4545(local134.anInt1388, level, local134.yFine, local134.xFine, local134.zFine);
 									}
 								}
 								if (local46.groundDecor != null) {
 									@Pc(167) GroundDecor local167 = local46.groundDecor;
-									local167.entity.method4545(0, local23, local167.anInt733, local167.xFine, local167.zFine);
+									local167.entity.method4545(0, level, local167.anInt733, local167.xFine, local167.zFine);
 								}
 								if (local46.scenery != null) {
 									for (local183 = 0; local183 < local46.sceneryLen; local183++) {
 										@Pc(192) Scenery local192 = local46.scenery[local183];
-										local192.entity.method4545(local192.anInt1714, local23, local192.anInt1706, local192.anInt1699, local192.anInt1703);
+										local192.entity.method4545(local192.anInt1714, level, local192.anInt1706, local192.anInt1699, local192.anInt1703);
 									}
 								}
 							}
@@ -3043,7 +3043,7 @@ public class SceneGraph {
 		if (GlRenderer.enabled) {
 			@Pc(244) GL2 gl = GlRenderer.gl;
 			gl.glPushMatrix();
-			gl.glTranslatef((float) -arg0, (float) -arg1, (float) -arg2);
+			gl.glTranslatef((float) -renderX, (float) -renderY, (float) -renderZ);
 			if (local240) {
 				UnderwaterMaterialRenderer.applyFogFade();
 				MaterialManager.setMaterial(-1, 3);
@@ -3051,8 +3051,8 @@ public class SceneGraph {
 				UnderwaterMaterialRenderer.method4609();
 				anInt3604 = -1;
 				anInt730 = -1;
-				for (local32 = 0; local32 < underwaterHdTiles[0].length; local32++) {
-					@Pc(285) GlTile local285 = underwaterHdTiles[0][local32];
+				for (x = 0; x < underwaterHdTiles[0].length; x++) {
+					@Pc(285) GlTile local285 = underwaterHdTiles[0][x];
 					@Pc(294) float local294 = 251.5F - (local285.blend ? 1.0F : 0.5F);
 					if (local285.underwaterColor != anInt3604) {
 						anInt3604 = local285.underwaterColor;
@@ -3063,25 +3063,25 @@ public class SceneGraph {
 				}
 				UnderwaterMaterialRenderer.method4608();
 			} else {
-				local32 = anInt5276;
+				x = firstVisibleLevel;
 				while (true) {
-					if (local32 >= levels) {
-						LightingManager.method2402(anInt4069, anInt4539, tiles);
+					if (x >= levels) {
+						LightingManager.method2402(cameraTileX, cameraTileZ, tiles);
 						break;
 					}
-					for (local37 = 0; local37 < underwaterHdTiles[local32].length; local37++) {
-						@Pc(336) GlTile local336 = underwaterHdTiles[local32][local37];
-						@Pc(350) float local350 = 201.5F - (float) local32 * 50.0F - (local336.blend ? 1.0F : 0.5F);
+					for (z = 0; z < underwaterHdTiles[x].length; z++) {
+						@Pc(336) GlTile local336 = underwaterHdTiles[x][z];
+						@Pc(350) float local350 = 201.5F - (float) x * 50.0F - (local336.blend ? 1.0F : 0.5F);
 						if (local336.texture != -1 && Rasteriser.textureProvider.getMaterialType(local336.texture) == MaterialManager.WATER && Preferences.highWaterDetail) {
 							WaterMaterialRenderer.method619(local336.underwaterColor);
 						}
 						local336.method1944(tiles, local350, false);
 					}
-					if (local32 == 0 && Preferences.sceneryShadowsType > 0) {
+					if (x == 0 && Preferences.sceneryShadowsType > 0) {
 						GlRenderer.method4159(101.5F);
-						ShadowManager.method4198(anInt4069, anInt4539, visibility, arg1, aBooleanArrayArray1, tileHeights[0]);
+						ShadowManager.method4198(cameraTileX, cameraTileZ, visibility, renderY, aBooleanArrayArray1, tileHeights[0]);
 					}
-					local32++;
+					x++;
 				}
 			}
 			gl.glPopMatrix();
@@ -3089,28 +3089,28 @@ public class SceneGraph {
 		@Pc(434) int local434;
 		@Pc(438) int local438;
 		@Pc(450) Tile local450;
-		@Pc(399) int local399;
-		@Pc(406) Tile[][] local406;
+		@Pc(399) int level;
+		@Pc(406) Tile[][] levelTiles;
 		@Pc(415) int local415;
 		@Pc(428) int local428;
-		for (local399 = anInt5276; local399 < levels; local399++) {
-			local406 = tiles[local399];
-			for (local37 = -visibility; local37 <= 0; local37++) {
-				local415 = anInt4069 + local37;
-				local183 = anInt4069 - local37;
+		for (level = firstVisibleLevel; level < levels; level++) {
+			levelTiles = tiles[level];
+			for (z = -visibility; z <= 0; z++) {
+				local415 = cameraTileX + z;
+				local183 = cameraTileX - z;
 				if (local415 >= LightingManager.anInt987 || local183 < LightingManager.anInt15) {
 					for (local428 = -visibility; local428 <= 0; local428++) {
-						local434 = anInt4539 + local428;
-						local438 = anInt4539 - local428;
+						local434 = cameraTileZ + local428;
+						local438 = cameraTileZ - local428;
 						if (local415 >= LightingManager.anInt987) {
 							if (local434 >= LightingManager.anInt4698) {
-								local450 = local406[local415][local434];
+								local450 = levelTiles[local415][local434];
 								if (local450 != null && local450.aBoolean45) {
 									method4245(local450, true);
 								}
 							}
 							if (local438 < LightingManager.anInt4866) {
-								local450 = local406[local415][local438];
+								local450 = levelTiles[local415][local438];
 								if (local450 != null && local450.aBoolean45) {
 									method4245(local450, true);
 								}
@@ -3118,13 +3118,13 @@ public class SceneGraph {
 						}
 						if (local183 < LightingManager.anInt15) {
 							if (local434 >= LightingManager.anInt4698) {
-								local450 = local406[local183][local434];
+								local450 = levelTiles[local183][local434];
 								if (local450 != null && local450.aBoolean45) {
 									method4245(local450, true);
 								}
 							}
 							if (local438 < LightingManager.anInt4866) {
-								local450 = local406[local183][local438];
+								local450 = levelTiles[local183][local438];
 								if (local450 != null && local450.aBoolean45) {
 									method4245(local450, true);
 								}
@@ -3140,24 +3140,25 @@ public class SceneGraph {
 				}
 			}
 		}
-		for (local399 = anInt5276; local399 < levels; local399++) {
-			local406 = tiles[local399];
-			for (local37 = -visibility; local37 <= 0; local37++) {
-				local415 = anInt4069 + local37;
-				local183 = anInt4069 - local37;
+		for (level = firstVisibleLevel; level < levels; level++) {
+			levelTiles = tiles[level];
+			for (z = -visibility; z <= 0; z++) {
+				local415 = cameraTileX + z;
+				local183 = cameraTileX - z;
+
 				if (local415 >= LightingManager.anInt987 || local183 < LightingManager.anInt15) {
 					for (local428 = -visibility; local428 <= 0; local428++) {
-						local434 = anInt4539 + local428;
-						local438 = anInt4539 - local428;
+						local434 = cameraTileZ + local428;
+						local438 = cameraTileZ - local428;
 						if (local415 >= LightingManager.anInt987) {
 							if (local434 >= LightingManager.anInt4698) {
-								local450 = local406[local415][local434];
+								local450 = levelTiles[local415][local434];
 								if (local450 != null && local450.aBoolean45) {
 									method4245(local450, false);
 								}
 							}
 							if (local438 < LightingManager.anInt4866) {
-								local450 = local406[local415][local438];
+								local450 = levelTiles[local415][local438];
 								if (local450 != null && local450.aBoolean45) {
 									method4245(local450, false);
 								}
@@ -3165,13 +3166,13 @@ public class SceneGraph {
 						}
 						if (local183 < LightingManager.anInt15) {
 							if (local434 >= LightingManager.anInt4698) {
-								local450 = local406[local183][local434];
+								local450 = levelTiles[local183][local434];
 								if (local450 != null && local450.aBoolean45) {
 									method4245(local450, false);
 								}
 							}
 							if (local438 < LightingManager.anInt4866) {
-								local450 = local406[local183][local438];
+								local450 = levelTiles[local183][local438];
 								if (local450 != null && local450.aBoolean45) {
 									method4245(local450, false);
 								}
@@ -3191,12 +3192,12 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!lg", name = "a", descriptor = "(I)V")
-	public static void method2750(@OriginalArg(0) int arg0) {
-		anInt5276 = arg0;
-		for (@Pc(3) int local3 = 0; local3 < width; local3++) {
-			for (@Pc(8) int local8 = 0; local8 < length; local8++) {
-				if (tiles[arg0][local3][local8] == null) {
-					tiles[arg0][local3][local8] = new Tile(arg0, local3, local8);
+	public static void initializeLevelMap(@OriginalArg(0) int level) {
+		firstVisibleLevel = level;
+		for (@Pc(3) int x = 0; x < width; x++) {
+			for (@Pc(8) int y = 0; y < length; y++) {
+				if (tiles[level][x][y] == null) {
+					tiles[level][x][y] = new Tile(level, x, y);
 				}
 			}
 		}
@@ -3208,24 +3209,24 @@ public class SceneGraph {
 		entity.primary = primary;
 		entity.xFine = x * 128 + 64;
 		entity.zFine = z * 128 + 64;
-		entity.anInt3057 = arg3;
+		entity.yFine = arg3;
 		entity.key = arg5;
 		entity.secondary = secondary;
 		entity.tertiary = tertiary;
-		@Pc(34) int local34 = 0;
-		@Pc(42) Tile local42 = tiles[level][x][z];
-		if (local42 != null) {
-			for (@Pc(46) int i = 0; i < local42.sceneryLen; i++) {
-				@Pc(55) Scenery scenery = local42.scenery[i];
+		@Pc(34) int minEntityY = 0;
+		@Pc(42) Tile tile = tiles[level][x][z];
+		if (tile != null) {
+			for (@Pc(46) int i = 0; i < tile.sceneryLen; i++) {
+				@Pc(55) Scenery scenery = tile.scenery[i];
 				if ((scenery.key & 0x400000L) == 4194304L) {
 					@Pc(66) int minY = scenery.entity.getMinY();
-					if (minY != -32768 && minY < local34) {
-						local34 = minY;
+					if (minY != -32768 && minY < minEntityY) {
+						minEntityY = minY;
 					}
 				}
 			}
 		}
-		entity.anInt3063 = -local34;
+		entity.minY = -minEntityY;
 		if (tiles[level][x][z] == null) {
 			tiles[level][x][z] = new Tile(level, x, z);
 		}
@@ -3564,24 +3565,24 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!pi", name = "a", descriptor = "([[[B[[B[[B[[I[[F[[I[[B[[B[[FI[[F[[I[[I[[II)[Lclient!hg;")
-	public static GlTile[] method3501(@OriginalArg(0) byte[][][] arg0, @OriginalArg(1) byte[][] arg1, @OriginalArg(2) byte[][] arg2, @OriginalArg(3) int[][] arg3, @OriginalArg(4) float[][] arg4, @OriginalArg(5) int[][] arg5, @OriginalArg(6) byte[][] arg6, @OriginalArg(7) byte[][] arg7, @OriginalArg(8) float[][] arg8, @OriginalArg(9) int arg9, @OriginalArg(10) float[][] arg10, @OriginalArg(11) int[][] arg11, @OriginalArg(12) int[][] arg12, @OriginalArg(13) int[][] arg13) {
+	public static GlTile[] method3501(@OriginalArg(0) byte[][][] renderFlags, @OriginalArg(1) byte[][] levelTileShapes, @OriginalArg(2) byte[][] levelTileUnderlays, @OriginalArg(3) int[][] underwaterOverlays, @OriginalArg(4) float[][] arg4, @OriginalArg(5) int[][] arg5, @OriginalArg(6) byte[][] arg6, @OriginalArg(7) byte[][] arg7, @OriginalArg(8) float[][] arg8, @OriginalArg(9) int arg9, @OriginalArg(10) float[][] arg10, @OriginalArg(11) int[][] arg11, @OriginalArg(12) int[][] arg12, @OriginalArg(13) int[][] arg13) {
 		@Pc(9) int[][] local9 = new int[105][105];
-		@Pc(16) int local16;
-		for (@Pc(11) int local11 = 1; local11 <= 103; local11++) {
-			for (local16 = 1; local16 <= 103; local16++) {
-				@Pc(25) byte local25 = arg2[local11][local16];
+		@Pc(16) int tileZ;
+		for (@Pc(11) int tileX = 1; tileX <= 103; tileX++) {
+			for (tileZ = 1; tileZ <= 103; tileZ++) {
+				@Pc(25) byte local25 = levelTileUnderlays[tileX][tileZ];
 				if (local25 == 0) {
-					local25 = arg2[local11 - 1][local16];
+					local25 = levelTileUnderlays[tileX - 1][tileZ];
 				}
 				if (local25 == 0) {
-					local25 = arg2[local11][local16 - 1];
+					local25 = levelTileUnderlays[tileX][tileZ - 1];
 				}
 				if (local25 == 0) {
-					local25 = arg2[local11 - 1][local16 - 1];
+					local25 = levelTileUnderlays[tileX - 1][tileZ - 1];
 				}
 				if (local25 != 0) {
 					@Pc(77) FluType local77 = FluTypeList.get((local25 & 0xFF) - 1);
-					local9[local11][local16] = (local77.texture + 1 << 16) + local77.anInt4156;
+					local9[tileX][tileZ] = (local77.texture + 1 << 16) + local77.anInt4156;
 				}
 			}
 		}
@@ -3590,27 +3591,27 @@ public class SceneGraph {
 		@Pc(161) int local161;
 		@Pc(169) int local169;
 		@Pc(112) int local112;
-		for (local16 = 1; local16 <= 102; local16++) {
+		for (tileZ = 1; tileZ <= 102; tileZ++) {
 			for (local112 = 1; local112 <= 102; local112++) {
-				if (arg2[local16][local112] != 0) {
+				if (levelTileUnderlays[tileZ][local112] != 0) {
 					@Pc(135) int[] local135;
-					if (arg6[local16][local112] == 0) {
+					if (arg6[tileZ][local112] == 0) {
 						local135 = anIntArrayArray35[0];
 					} else {
-						local135 = anIntArrayArray8[arg1[local16][local112]];
+						local135 = anIntArrayArray8[levelTileShapes[tileZ][local112]];
 						if (local135.length == 0) {
 							continue;
 						}
 					}
 					local155 = 0;
-					local161 = local9[local16][local112];
-					local169 = local9[local16 + 1][local112];
+					local161 = local9[tileZ][local112];
+					local169 = local9[tileZ + 1][local112];
 					if (arg5 != null) {
-						local155 = arg5[local16][local112] & 0xFFFFFF;
+						local155 = arg5[tileZ][local112] & 0xFFFFFF;
 					}
 					@Pc(188) long local188 = (long) local155 | (long) local169 << 32;
-					@Pc(196) int local196 = local9[local16][local112 + 1];
-					@Pc(206) int local206 = local9[local16 + 1][local112 + 1];
+					@Pc(196) int local196 = local9[tileZ][local112 + 1];
+					@Pc(206) int local206 = local9[tileZ + 1][local112 + 1];
 					@Pc(214) long local214 = (long) local196 << 32 | (long) local155;
 					@Pc(219) int local219 = local135.length / 2;
 					@Pc(227) long local227 = (long) local155 | (long) local161 << 32;
@@ -3656,13 +3657,13 @@ public class SceneGraph {
 		for (local493 = (GlTile) local103.head(); local493 != null; local493 = (GlTile) local103.next()) {
 			local493.method1940();
 		}
-		for (local16 = 1; local16 <= 102; local16++) {
+		for (tileZ = 1; tileZ <= 102; tileZ++) {
 			for (local112 = 1; local112 <= 102; local112++) {
-				@Pc(524) byte local524 = arg2[local16][local112];
+				@Pc(524) byte local524 = levelTileUnderlays[tileZ][local112];
 				if (local524 != 0) {
-					if ((arg0[arg9][local16][local112] & 0x8) != 0) {
+					if ((renderFlags[arg9][tileZ][local112] & 0x8) != 0) {
 						local155 = 0;
-					} else if ((arg0[1][local16][local112] & 0x2) == 2 && arg9 > 0) {
+					} else if ((renderFlags[1][tileZ][local112] & 0x2) == 2 && arg9 > 0) {
 						local155 = arg9 - 1;
 					} else {
 						local155 = arg9;
@@ -3671,8 +3672,8 @@ public class SceneGraph {
 					@Pc(574) boolean[] local574 = null;
 					local169 = 128;
 					if (arg5 != null) {
-						local169 = arg5[local16][local112] >>> 24 << 3;
-						local161 = arg5[local16][local112] & 0xFFFFFF;
+						local169 = arg5[tileZ][local112] >>> 24 << 3;
+						local161 = arg5[tileZ][local112] & 0xFFFFFF;
 					}
 					@Pc(655) int local655;
 					@Pc(712) int local712;
@@ -3680,34 +3681,34 @@ public class SceneGraph {
 					@Pc(628) byte local628;
 					@Pc(678) int local678;
 					@Pc(754) int local754;
-					if (arg6[local16][local112] == 0) {
-						local655 = local524 == arg2[local16 - 1][local112 - 1] ? 1 : -1;
+					if (arg6[tileZ][local112] == 0) {
+						local655 = local524 == levelTileUnderlays[tileZ - 1][local112 - 1] ? 1 : -1;
 						local614 = anIntArrayArray35[0];
-						local678 = local524 == arg2[local16 + 1][local112 - 1] ? 1 : -1;
-						if (arg2[local16][local112 - 1] == local524) {
+						local678 = local524 == levelTileUnderlays[tileZ + 1][local112 - 1] ? 1 : -1;
+						if (levelTileUnderlays[tileZ][local112 - 1] == local524) {
 							local678++;
 							local655++;
 						} else {
 							local655--;
 							local678--;
 						}
-						local712 = local524 == arg2[local16 + 1][local112 + 1] ? 1 : -1;
-						if (local524 == arg2[local16 + 1][local112]) {
+						local712 = local524 == levelTileUnderlays[tileZ + 1][local112 + 1] ? 1 : -1;
+						if (local524 == levelTileUnderlays[tileZ + 1][local112]) {
 							local712++;
 							local678++;
 						} else {
 							local678--;
 							local712--;
 						}
-						local754 = local524 == arg2[local16 - 1][local112 + 1] ? 1 : -1;
-						if (arg2[local16][local112 + 1] == local524) {
+						local754 = local524 == levelTileUnderlays[tileZ - 1][local112 + 1] ? 1 : -1;
+						if (levelTileUnderlays[tileZ][local112 + 1] == local524) {
 							local754++;
 							local712++;
 						} else {
 							local712--;
 							local754--;
 						}
-						if (arg2[local16 - 1][local112] == local524) {
+						if (levelTileUnderlays[tileZ - 1][local112] == local524) {
 							local754++;
 							local655++;
 						} else {
@@ -3723,48 +3724,48 @@ public class SceneGraph {
 							local789 = -local789;
 						}
 						local628 = (byte) (local794 <= local789 ? 0 : 1);
-						arg7[local16][local112] = local628;
+						arg7[tileZ][local112] = local628;
 					} else {
-						local614 = anIntArrayArray8[arg1[local16][local112]];
-						local574 = aBooleanArrayArray2[arg1[local16][local112]];
-						local628 = arg7[local16][local112];
+						local614 = anIntArrayArray8[levelTileShapes[tileZ][local112]];
+						local574 = aBooleanArrayArray2[levelTileShapes[tileZ][local112]];
+						local628 = arg7[tileZ][local112];
 						if (local614.length == 0) {
 							continue;
 						}
 					}
-					local655 = local9[local16][local112];
-					local678 = local9[local16 + 1][local112];
-					local712 = local9[local16 + 1][local112 + 1];
+					local655 = local9[tileZ][local112];
+					local678 = local9[tileZ + 1][local112];
+					local712 = local9[tileZ + 1][local112 + 1];
 					@Pc(861) long local861 = (long) local655 << 32 | (long) local161;
 					@Pc(869) long local869 = (long) local678 << 32 | (long) local161;
 					@Pc(877) long local877 = (long) local712 << 32 | (long) local161;
-					@Pc(883) int local883 = arg11[local16][local112];
-					local754 = local9[local16][local112 + 1];
-					@Pc(901) int local901 = arg11[local16 + 1][local112 + 1];
-					@Pc(909) int local909 = arg11[local16 + 1][local112];
+					@Pc(883) int local883 = arg11[tileZ][local112];
+					local754 = local9[tileZ][local112 + 1];
+					@Pc(901) int local901 = arg11[tileZ + 1][local112 + 1];
+					@Pc(909) int local909 = arg11[tileZ + 1][local112];
 					@Pc(917) long local917 = (long) local161 | (long) local754 << 32;
-					@Pc(925) int local925 = arg11[local16][local112 + 1];
-					@Pc(931) int local931 = arg3[local16][local112];
-					@Pc(939) int local939 = arg3[local16 + 1][local112];
-					@Pc(949) int local949 = arg3[local16 + 1][local112 + 1];
-					@Pc(957) int local957 = arg3[local16][local112 + 1];
+					@Pc(925) int local925 = arg11[tileZ][local112 + 1];
+					@Pc(931) int local931 = underwaterOverlays[tileZ][local112];
+					@Pc(939) int local939 = underwaterOverlays[tileZ + 1][local112];
+					@Pc(949) int local949 = underwaterOverlays[tileZ + 1][local112 + 1];
+					@Pc(957) int local957 = underwaterOverlays[tileZ][local112 + 1];
 					@Pc(963) int local963 = (local678 >> 16) - 1;
 					@Pc(969) int local969 = (local655 >> 16) - 1;
 					@Pc(975) int local975 = (local712 >> 16) - 1;
 					@Pc(981) GlTile local981 = (GlTile) local103.get(local861);
-					method1291(arg13, local655 <= local655, method588(local969, local883, local931), local981, local614, local112, local155, local16, local655 <= local712, arg8, local754 >= local655, arg4, local169, method588(local969, local925, local957), method588(local969, local901, local949), local655 <= local678, arg12, arg10, local628, method588(local969, local909, local939), local574);
+					method1291(arg13, local655 <= local655, method588(local969, local883, local931), local981, local614, local112, local155, tileZ, local655 <= local712, arg8, local754 >= local655, arg4, local169, method588(local969, local925, local957), method588(local969, local901, local949), local655 <= local678, arg12, arg10, local628, method588(local969, local909, local939), local574);
 					@Pc(1050) int local1050 = (local754 >> 16) - 1;
 					if (local869 != local861) {
 						local981 = (GlTile) local103.get(local869);
-						method1291(arg13, local678 <= local655, method588(local963, local883, local931), local981, local614, local112, local155, local16, local712 >= local678, arg8, local678 <= local754, arg4, local169, method588(local963, local925, local957), method588(local963, local901, local949), local678 <= local678, arg12, arg10, local628, method588(local963, local909, local939), local574);
+						method1291(arg13, local678 <= local655, method588(local963, local883, local931), local981, local614, local112, local155, tileZ, local712 >= local678, arg8, local678 <= local754, arg4, local169, method588(local963, local925, local957), method588(local963, local901, local949), local678 <= local678, arg12, arg10, local628, method588(local963, local909, local939), local574);
 					}
 					if (local877 != local861 && local877 != local869) {
 						local981 = (GlTile) local103.get(local877);
-						method1291(arg13, local655 >= local712, method588(local975, local883, local931), local981, local614, local112, local155, local16, local712 <= local712, arg8, local712 <= local754, arg4, local169, method588(local975, local925, local957), method588(local975, local901, local949), local678 >= local712, arg12, arg10, local628, method588(local975, local909, local939), local574);
+						method1291(arg13, local655 >= local712, method588(local975, local883, local931), local981, local614, local112, local155, tileZ, local712 <= local712, arg8, local712 <= local754, arg4, local169, method588(local975, local925, local957), method588(local975, local901, local949), local678 >= local712, arg12, arg10, local628, method588(local975, local909, local939), local574);
 					}
 					if (local917 != local861 && local917 != local869 && local917 != local877) {
 						local981 = (GlTile) local103.get(local917);
-						method1291(arg13, local754 <= local655, method588(local1050, local883, local931), local981, local614, local112, local155, local16, local754 <= local712, arg8, local754 >= local754, arg4, local169, method588(local1050, local925, local957), method588(local1050, local901, local949), local678 >= local754, arg12, arg10, local628, method588(local1050, local909, local939), local574);
+						method1291(arg13, local754 <= local655, method588(local1050, local883, local931), local981, local614, local112, local155, tileZ, local754 <= local712, arg8, local754 >= local754, arg4, local169, method588(local1050, local925, local957), method588(local1050, local901, local949), local678 >= local754, arg12, arg10, local628, method588(local1050, local909, local939), local574);
 					}
 				}
 			}
@@ -3776,11 +3777,11 @@ public class SceneGraph {
 				local493.method1943();
 			}
 		}
-		local16 = local103.size();
-		@Pc(1348) GlTile[] local1348 = new GlTile[local16];
+		tileZ = local103.size();
+		@Pc(1348) GlTile[] local1348 = new GlTile[tileZ];
 		local103.method3865(local1348);
-		@Pc(1358) long[] local1358 = new long[local16];
-		for (local155 = 0; local155 < local16; local155++) {
+		@Pc(1358) long[] local1358 = new long[tileZ];
+		for (local155 = 0; local155 < tileZ; local155++) {
 			local1358[local155] = local1348[local155].key;
 		}
 		ArrayUtils.sort(local1358, local1348);
@@ -3809,9 +3810,9 @@ public class SceneGraph {
 			return;
 		}
 		@Pc(39) int local39;
-		if (!allLevelsAreVisible() && (renderFlags[0][arg1][arg4] & 0x2) == 0) {
+		if (!allLevelsAreVisible() && (tileRenderFlags[0][arg1][arg4] & 0x2) == 0) {
 			local39 = arg2;
-			if ((renderFlags[arg2][arg1][arg4] & 0x8) != 0) {
+			if ((tileRenderFlags[arg2][arg1][arg4] & 0x8) != 0) {
 				local39 = 0;
 			}
 			if (local39 != centralPlane) {
@@ -3819,7 +3820,7 @@ public class SceneGraph {
 			}
 		}
 		local39 = arg2;
-		if (arg2 < 3 && (renderFlags[1][arg1][arg4] & 0x2) == 2) {
+		if (arg2 < 3 && (tileRenderFlags[1][arg1][arg4] & 0x2) == 2) {
 			local39 = arg2 + 1;
 		}
 		method1144(arg4, arg1, arg2, arg6, local39, PathFinder.collisionMaps[arg2]);
@@ -3844,8 +3845,8 @@ public class SceneGraph {
 
 	@OriginalMember(owner = "client!ac", name = "a", descriptor = "(IIII)I")
 	public static int getRenderLevel(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(3) int arg2) {
-		if ((renderFlags[arg2][arg1][arg0] & 0x8) == 0) {
-			return arg2 <= 0 || (renderFlags[1][arg1][arg0] & 0x2) == 0 ? arg2 : arg2 - 1;
+		if ((tileRenderFlags[arg2][arg1][arg0] & 0x8) == 0) {
+			return arg2 <= 0 || (tileRenderFlags[1][arg1][arg0] & 0x2) == 0 ? arg2 : arg2 - 1;
 		} else {
 			return 0;
 		}
@@ -3854,17 +3855,17 @@ public class SceneGraph {
 	@OriginalMember(owner = "client!ke", name = "a", descriptor = "(Lclient!rh;IIIIIIIZ)V")
 	public static void method2610(@OriginalArg(0) PlainTile arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5, @OriginalArg(6) int arg6, @OriginalArg(7) int arg7, @OriginalArg(8) boolean arg8) {
 		@Pc(6) int local6;
-		@Pc(7) int local7 = local6 = (arg6 << 7) - anInt3555;
+		@Pc(7) int local7 = local6 = (arg6 << 7) - cameraX;
 		@Pc(14) int local14;
-		@Pc(15) int local15 = local14 = (arg7 << 7) - anInt4903;
+		@Pc(15) int local15 = local14 = (arg7 << 7) - cameraZ;
 		@Pc(20) int local20;
 		@Pc(21) int local21 = local20 = local7 + 128;
 		@Pc(26) int local26;
 		@Pc(27) int local27 = local26 = local15 + 128;
-		@Pc(37) int local37 = tileHeights[arg1][arg6][arg7] - anInt3947;
-		@Pc(49) int local49 = tileHeights[arg1][arg6 + 1][arg7] - anInt3947;
-		@Pc(63) int local63 = tileHeights[arg1][arg6 + 1][arg7 + 1] - anInt3947;
-		@Pc(75) int local75 = tileHeights[arg1][arg6][arg7 + 1] - anInt3947;
+		@Pc(37) int local37 = tileHeights[arg1][arg6][arg7] - cameraY;
+		@Pc(49) int local49 = tileHeights[arg1][arg6 + 1][arg7] - cameraY;
+		@Pc(63) int local63 = tileHeights[arg1][arg6 + 1][arg7 + 1] - cameraY;
+		@Pc(75) int local75 = tileHeights[arg1][arg6][arg7 + 1] - cameraY;
 		@Pc(85) int local85 = local15 * arg4 + local7 * arg5 >> 16;
 		@Pc(95) int local95 = local15 * arg5 - local7 * arg4 >> 16;
 		@Pc(97) int local97 = local85;
@@ -3955,20 +3956,20 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!al", name = "a", descriptor = "(III)Z")
-	public static boolean method187(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2) {
-		@Pc(7) int local7 = anIntArrayArrayArray12[arg0][arg1][arg2];
+	public static boolean method187(@OriginalArg(0) int plane, @OriginalArg(1) int tileX, @OriginalArg(2) int tileZ) {
+		@Pc(7) int local7 = anIntArrayArrayArray12[plane][tileX][tileZ];
 		if (local7 == -anInt437) {
 			return false;
 		} else if (local7 == anInt437) {
 			return true;
 		} else {
-			@Pc(22) int local22 = arg1 << 7;
-			@Pc(26) int local26 = arg2 << 7;
-			if (method4394(local22 + 1, tileHeights[arg0][arg1][arg2], local26 + 1) && method4394(local22 + 128 - 1, tileHeights[arg0][arg1 + 1][arg2], local26 + 1) && method4394(local22 + 128 - 1, tileHeights[arg0][arg1 + 1][arg2 + 1], local26 + 128 - 1) && method4394(local22 + 1, tileHeights[arg0][arg1][arg2 + 1], local26 + 128 - 1)) {
-				anIntArrayArrayArray12[arg0][arg1][arg2] = anInt437;
+			@Pc(22) int fineX = tileX << 7;
+			@Pc(26) int fineZ = tileZ << 7;
+			if (method4394(fineX + 1, tileHeights[plane][tileX][tileZ], fineZ + 1) && method4394(fineX + 128 - 1, tileHeights[plane][tileX + 1][tileZ], fineZ + 1) && method4394(fineX + 128 - 1, tileHeights[plane][tileX + 1][tileZ + 1], fineZ + 128 - 1) && method4394(fineX + 1, tileHeights[plane][tileX][tileZ + 1], fineZ + 128 - 1)) {
+				anIntArrayArrayArray12[plane][tileX][tileZ] = anInt437;
 				return true;
 			} else {
-				anIntArrayArrayArray12[arg0][arg1][arg2] = -anInt437;
+				anIntArrayArrayArray12[plane][tileX][tileZ] = -anInt437;
 				return false;
 			}
 		}
@@ -3976,17 +3977,17 @@ public class SceneGraph {
 
 	@OriginalMember(owner = "client!mj", name = "a", descriptor = "(IIIII)Z")
 	public static boolean method3049(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
-		@Pc(9) int local9 = arg3 * anInt5205 + arg0 * anInt2222 >> 16;
-		@Pc(19) int local19 = arg3 * anInt2222 - arg0 * anInt5205 >> 16;
-		@Pc(29) int local29 = arg1 * anInt2886 + local19 * anInt3038 >> 16;
-		@Pc(39) int local39 = arg1 * anInt3038 - local19 * anInt2886 >> 16;
+		@Pc(9) int local9 = arg3 * yawSin + arg0 * yawCos >> 16;
+		@Pc(19) int local19 = arg3 * yawCos - arg0 * yawSin >> 16;
+		@Pc(29) int local29 = arg1 * pitchSin + local19 * pitchCos >> 16;
+		@Pc(39) int local39 = arg1 * pitchCos - local19 * pitchSin >> 16;
 		if (local29 < 1) {
 			local29 = 1;
 		}
 		@Pc(50) int local50 = (local9 << 9) / local29;
 		@Pc(56) int local56 = (local39 << 9) / local29;
-		@Pc(66) int local66 = arg2 * anInt2886 + local19 * anInt3038 >> 16;
-		@Pc(76) int local76 = arg2 * anInt3038 - local19 * anInt2886 >> 16;
+		@Pc(66) int local66 = arg2 * pitchSin + local19 * pitchCos >> 16;
+		@Pc(76) int local76 = arg2 * pitchCos - local19 * pitchSin >> 16;
 		if (local66 < 1) {
 			local66 = 1;
 		}
@@ -4091,13 +4092,13 @@ public class SceneGraph {
 			@Pc(158) int local158;
 			@Pc(137) boolean local137;
 			if (local10.anInt4453 == 1) {
-				local14 = local10.anInt4452 + visibility - anInt4069;
+				local14 = local10.anInt4452 + visibility - cameraTileX;
 				if (local14 >= 0 && local14 <= visibility + visibility) {
-					local115 = local10.anInt4461 + visibility - anInt4539;
+					local115 = local10.anInt4461 + visibility - cameraTileZ;
 					if (local115 < 0) {
 						local115 = 0;
 					}
-					local126 = local10.anInt4464 + visibility - anInt4539;
+					local126 = local10.anInt4464 + visibility - cameraTileZ;
 					if (local126 > visibility + visibility) {
 						local126 = visibility + visibility;
 					}
@@ -4109,7 +4110,7 @@ public class SceneGraph {
 						}
 					}
 					if (local137) {
-						local158 = anInt3555 - local10.anInt4460;
+						local158 = cameraX - local10.anInt4460;
 						if (local158 > 32) {
 							local10.anInt4462 = 1;
 						} else {
@@ -4119,21 +4120,21 @@ public class SceneGraph {
 							local10.anInt4462 = 2;
 							local158 = -local158;
 						}
-						local10.anInt4454 = (local10.anInt4458 - anInt4903 << 8) / local158;
-						local10.anInt4450 = (local10.anInt4449 - anInt4903 << 8) / local158;
-						local10.anInt4459 = (local10.anInt4444 - anInt3947 << 8) / local158;
-						local10.anInt4463 = (local10.anInt4447 - anInt3947 << 8) / local158;
+						local10.anInt4454 = (local10.anInt4458 - cameraZ << 8) / local158;
+						local10.anInt4450 = (local10.anInt4449 - cameraZ << 8) / local158;
+						local10.anInt4459 = (local10.anInt4444 - cameraY << 8) / local158;
+						local10.anInt4463 = (local10.anInt4447 - cameraY << 8) / local158;
 						aClass120Array2[anInt4870++] = local10;
 					}
 				}
 			} else if (local10.anInt4453 == 2) {
-				local14 = local10.anInt4461 + visibility - anInt4539;
+				local14 = local10.anInt4461 + visibility - cameraTileZ;
 				if (local14 >= 0 && local14 <= visibility + visibility) {
-					local115 = local10.anInt4452 + visibility - anInt4069;
+					local115 = local10.anInt4452 + visibility - cameraTileX;
 					if (local115 < 0) {
 						local115 = 0;
 					}
-					local126 = local10.anInt4446 + visibility - anInt4069;
+					local126 = local10.anInt4446 + visibility - cameraTileX;
 					if (local126 > visibility + visibility) {
 						local126 = visibility + visibility;
 					}
@@ -4145,7 +4146,7 @@ public class SceneGraph {
 						}
 					}
 					if (local137) {
-						local158 = anInt4903 - local10.anInt4458;
+						local158 = cameraZ - local10.anInt4458;
 						if (local158 > 32) {
 							local10.anInt4462 = 3;
 						} else {
@@ -4155,30 +4156,30 @@ public class SceneGraph {
 							local10.anInt4462 = 4;
 							local158 = -local158;
 						}
-						local10.anInt4448 = (local10.anInt4460 - anInt3555 << 8) / local158;
-						local10.anInt4456 = (local10.anInt4445 - anInt3555 << 8) / local158;
-						local10.anInt4459 = (local10.anInt4444 - anInt3947 << 8) / local158;
-						local10.anInt4463 = (local10.anInt4447 - anInt3947 << 8) / local158;
+						local10.anInt4448 = (local10.anInt4460 - cameraX << 8) / local158;
+						local10.anInt4456 = (local10.anInt4445 - cameraX << 8) / local158;
+						local10.anInt4459 = (local10.anInt4444 - cameraY << 8) / local158;
+						local10.anInt4463 = (local10.anInt4447 - cameraY << 8) / local158;
 						aClass120Array2[anInt4870++] = local10;
 					}
 				}
 			} else if (local10.anInt4453 == 4) {
-				local14 = local10.anInt4444 - anInt3947;
+				local14 = local10.anInt4444 - cameraY;
 				if (local14 > 128) {
-					local115 = local10.anInt4461 + visibility - anInt4539;
+					local115 = local10.anInt4461 + visibility - cameraTileZ;
 					if (local115 < 0) {
 						local115 = 0;
 					}
-					local126 = local10.anInt4464 + visibility - anInt4539;
+					local126 = local10.anInt4464 + visibility - cameraTileZ;
 					if (local126 > visibility + visibility) {
 						local126 = visibility + visibility;
 					}
 					if (local115 <= local126) {
-						@Pc(408) int local408 = local10.anInt4452 + visibility - anInt4069;
+						@Pc(408) int local408 = local10.anInt4452 + visibility - cameraTileX;
 						if (local408 < 0) {
 							local408 = 0;
 						}
-						local158 = local10.anInt4446 + visibility - anInt4069;
+						local158 = local10.anInt4446 + visibility - cameraTileX;
 						if (local158 > visibility + visibility) {
 							local158 = visibility + visibility;
 						}
@@ -4194,10 +4195,10 @@ public class SceneGraph {
 						}
 						if (local430) {
 							local10.anInt4462 = 5;
-							local10.anInt4448 = (local10.anInt4460 - anInt3555 << 8) / local14;
-							local10.anInt4456 = (local10.anInt4445 - anInt3555 << 8) / local14;
-							local10.anInt4454 = (local10.anInt4458 - anInt4903 << 8) / local14;
-							local10.anInt4450 = (local10.anInt4449 - anInt4903 << 8) / local14;
+							local10.anInt4448 = (local10.anInt4460 - cameraX << 8) / local14;
+							local10.anInt4456 = (local10.anInt4445 - cameraX << 8) / local14;
+							local10.anInt4454 = (local10.anInt4458 - cameraZ << 8) / local14;
+							local10.anInt4450 = (local10.anInt4449 - cameraZ << 8) / local14;
 							aClass120Array2[anInt4870++] = local10;
 						}
 					}
@@ -4233,9 +4234,9 @@ public class SceneGraph {
 		@Pc(29) int local29;
 		@Pc(39) int local39;
 		for (local5 = 0; local5 < local3; local5++) {
-			local15 = arg0.anIntArray168[local5] - anInt3555;
-			local22 = arg0.anIntArray160[local5] - anInt3947;
-			local29 = arg0.anIntArray163[local5] - anInt4903;
+			local15 = arg0.anIntArray168[local5] - cameraX;
+			local22 = arg0.anIntArray160[local5] - cameraY;
+			local29 = arg0.anIntArray163[local5] - cameraZ;
 			local39 = local29 * arg3 + local15 * arg4 >> 16;
 			@Pc(49) int local49 = local29 * arg4 - local15 * arg3 >> 16;
 			@Pc(61) int local61 = local22 * arg2 - local49 * arg1 >> 16;
@@ -5267,7 +5268,7 @@ public class SceneGraph {
 					local194 = local529.z >> 7;
 					local190 = local529.x >> 7;
 					if (local190 >= 0 && local194 >= 0 && local190 < 104 && local194 < 104) {
-						local529.aBoolean125 = (renderFlags[1][local190][local194] & 0x2) != 0;
+						local529.aBoolean125 = (tileRenderFlags[1][local190][local194] & 0x2) != 0;
 						local529.y = tileHeights[local529.level][local190][local194] - local529.y;
 						LightingManager.method2389(local529);
 					}
@@ -5433,7 +5434,7 @@ public class SceneGraph {
 						local417 = local517.x >> 7;
 						local255 = local517.z >> 7;
 						if (local417 >= 0 && local255 >= 0 && local417 < 104 && local255 < 104) {
-							local517.aBoolean125 = (renderFlags[1][local417][local255] & 0x2) != 0;
+							local517.aBoolean125 = (tileRenderFlags[1][local417][local255] & 0x2) != 0;
 							local517.y = tileHeights[local517.level][local417][local255] - local517.y;
 							LightingManager.method2389(local517);
 						}

--- a/client/src/main/java/rt4/SceneGraph.java
+++ b/client/src/main/java/rt4/SceneGraph.java
@@ -1637,7 +1637,7 @@ public class SceneGraph {
 		while (true) {
 			@Pc(8) Tile node;
 			@Pc(18) int nodeX;
-			@Pc(21) int nodeY;
+			@Pc(21) int nodeZ;
 			@Pc(24) int level;
 			@Pc(27) int plane;
 			@Pc(31) Tile[][] levelTiles;
@@ -1671,14 +1671,14 @@ public class SceneGraph {
 												}
 											} while (!node.aBoolean46);
 											nodeX = node.x;
-											nodeY = node.y;
+											nodeZ = node.z;
 											level = node.level;
 											plane = node.plane;
 											levelTiles = tiles[level];
 											@Pc(33) float local33 = 0.0F;
 											if (GlRenderer.enabled) {
 												if (underwaterTileHeights == tileHeights) {
-													sceneryLength = underWaterColors[nodeX][nodeY];
+													sceneryLength = underWaterColors[nodeX][nodeZ];
 													var10 = sceneryLength & 0xFFFFFF;
 													if (var10 != anInt3604) {
 														anInt3604 = var10;
@@ -1690,7 +1690,7 @@ public class SceneGraph {
 														anInt730 = sceneryIndex;
 														MaterialManager.method2761(sceneryIndex);
 													}
-													local115 = surfaceTileHeights[0][nodeX][nodeY] + surfaceTileHeights[0][nodeX + 1][nodeY] + surfaceTileHeights[0][nodeX][nodeY + 1] + surfaceTileHeights[0][nodeX + 1][nodeY + 1] >> 2;
+													local115 = surfaceTileHeights[0][nodeX][nodeZ] + surfaceTileHeights[0][nodeX + 1][nodeZ] + surfaceTileHeights[0][nodeX][nodeZ + 1] + surfaceTileHeights[0][nodeX + 1][nodeZ + 1] >> 2;
 													MaterialManager.setMaterial(-local115, 3);
 													local33 = 201.5F;
 													GlRenderer.method4159(local33);
@@ -1704,31 +1704,31 @@ public class SceneGraph {
 											}
 											if (arg1) {
 												if (level > 0) {
-													local153 = tiles[level - 1][nodeX][nodeY];
+													local153 = tiles[level - 1][nodeX][nodeZ];
 													if (local153 != null && local153.aBoolean46) {
 														continue;
 													}
 												}
 												if (nodeX <= cameraTileX && nodeX > LightingManager.anInt987) {
-													local153 = levelTiles[nodeX - 1][nodeY];
+													local153 = levelTiles[nodeX - 1][nodeZ];
 													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x1) == 0)) {
 														continue;
 													}
 												}
 												if (nodeX >= cameraTileX && nodeX < LightingManager.anInt15 - 1) {
-													local153 = levelTiles[nodeX + 1][nodeY];
+													local153 = levelTiles[nodeX + 1][nodeZ];
 													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x4) == 0)) {
 														continue;
 													}
 												}
-												if (nodeY <= cameraTileZ && nodeY > LightingManager.anInt4698) {
-													local153 = levelTiles[nodeX][nodeY - 1];
+												if (nodeZ <= cameraTileZ && nodeZ > LightingManager.anInt4698) {
+													local153 = levelTiles[nodeX][nodeZ - 1];
 													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x8) == 0)) {
 														continue;
 													}
 												}
-												if (nodeY >= cameraTileZ && nodeY < LightingManager.anInt4866 - 1) {
-													local153 = levelTiles[nodeX][nodeY + 1];
+												if (nodeZ >= cameraTileZ && nodeZ < LightingManager.anInt4866 - 1) {
+													local153 = levelTiles[nodeX][nodeZ + 1];
 													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x2) == 0)) {
 														continue;
 													}
@@ -1744,17 +1744,17 @@ public class SceneGraph {
 												}
 												if (local153.plainTile == null) {
 													if (local153.shapedTile != null) {
-														method2762(local153.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, method187(0, nodeX, nodeY));
+														method2762(local153.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, method187(0, nodeX, nodeZ));
 													}
 												} else
-													method2610(local153.plainTile, 0, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, method187(0, nodeX, nodeY));
+													method2610(local153.plainTile, 0, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, method187(0, nodeX, nodeZ));
 												var22 = local153.wall;
 												if (var22 != null) {
 													if (GlRenderer.enabled) {
 														if ((var22.anInt3049 & node.anInt670) == 0) {
-															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 														} else {
-															LightingManager.method2388(var22.anInt3049, cameraX, cameraY, cameraZ, plane, nodeX, nodeY);
+															LightingManager.method2388(var22.anInt3049, cameraX, cameraY, cameraZ, plane, nodeX, nodeZ);
 														}
 													}
 													var22.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, var22.xFine - cameraX, var22.anInt3051 - cameraY, var22.zFine - cameraZ, var22.key, level, null);
@@ -1763,7 +1763,7 @@ public class SceneGraph {
 													scenery = local153.scenery[sceneryIndex];
 													if (scenery != null) {
 														if (GlRenderer.enabled) {
-															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 														}
 														scenery.entity.render(scenery.anInt1714, pitchSin, pitchCos, yawSin, yawCos, scenery.anInt1699 - cameraX, scenery.anInt1706 - cameraY, scenery.anInt1703 - cameraZ, scenery.key, level, null);
 													}
@@ -1775,19 +1775,19 @@ public class SceneGraph {
 											var24 = false;
 											if (node.plainTile == null) {
 												if (node.shapedTile != null) {
-													if (method187(plane, nodeX, nodeY)) {
-														method2762(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, true);
+													if (method187(plane, nodeX, nodeZ)) {
+														method2762(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, true);
 													} else {
 														var24 = true;
-														method2762(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, false);
+														method2762(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, false);
 													}
 												}
-											} else if (method187(plane, nodeX, nodeY)) {
-												method2610(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, true);
+											} else if (method187(plane, nodeX, nodeZ)) {
+												method2610(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, true);
 											} else {
 												var24 = true;
 												if (node.plainTile.anInt4865 != 12345678 || MiniMenu.aBoolean187 && level <= MiniMenu.anInt3902) {
-													method2610(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeY, false);
+													method2610(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, false);
 												}
 											}
 											if (var24) {
@@ -1797,7 +1797,7 @@ public class SceneGraph {
 														GlRenderer.method4159(local33 + 50.0F - 1.5F);
 													}
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 													}
 													local549.entity.render(0, pitchSin, pitchCos, yawSin, yawCos, local549.xFine - cameraX, local549.anInt733 - cameraY, local549.zFine - cameraZ, local549.key, level, null);
 													if (GlRenderer.enabled && local549.aBoolean49) {
@@ -1815,9 +1815,9 @@ public class SceneGraph {
 												} else if (cameraTileX < nodeX) {
 													var10 += 2;
 												}
-												if (cameraTileZ == nodeY) {
+												if (cameraTileZ == nodeZ) {
 													var10 += 3;
-												} else if (cameraTileZ > nodeY) {
+												} else if (cameraTileZ > nodeZ) {
 													var10 += 6;
 												}
 												sceneryIndex = anIntArray324[var10];
@@ -1843,26 +1843,26 @@ public class SceneGraph {
 													node.anInt665 = anIntArray307[var10];
 													node.anInt667 = 9 - node.anInt665;
 												}
-												if ((wall.anInt3049 & sceneryIndex) != 0 && !method3850(plane, nodeX, nodeY, wall.anInt3049)) {
+												if ((wall.anInt3049 & sceneryIndex) != 0 && !method3850(plane, nodeX, nodeZ, wall.anInt3049)) {
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 													}
 													wall.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, wall.xFine - cameraX, wall.anInt3051 - cameraY, wall.zFine - cameraZ, wall.key, level, null);
 												}
-												if ((wall.anInt3052 & sceneryIndex) != 0 && !method3850(plane, nodeX, nodeY, wall.anInt3052)) {
+												if ((wall.anInt3052 & sceneryIndex) != 0 && !method3850(plane, nodeX, nodeZ, wall.anInt3052)) {
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 													}
 													wall.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, wall.xFine - cameraX, wall.anInt3051 - cameraY, wall.zFine - cameraZ, wall.key, level, null);
 												}
 											}
-											if (wallDecor != null && !method4611(plane, nodeX, nodeY, wallDecor.primary.getMinY())) {
+											if (wallDecor != null && !method4611(plane, nodeX, nodeZ, wallDecor.primary.getMinY())) {
 												if (GlRenderer.enabled) {
 													GlRenderer.method4159(local33 - 0.5F);
 												}
 												if ((wallDecor.anInt1395 & sceneryIndex) != 0) {
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 													}
 													wallDecor.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, wallDecor.xFine + wallDecor.xOffset - cameraX, wallDecor.yFine - cameraY, wallDecor.zFine + wallDecor.zOffset - cameraZ, wallDecor.key, level, null);
 												} else if (wallDecor.anInt1395 == 256) {
@@ -1883,12 +1883,12 @@ public class SceneGraph {
 													}
 													if (local928 < var18) {
 														if (GlRenderer.enabled) {
-															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 														}
 														wallDecor.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, local894 + wallDecor.xOffset, local899, local904 + wallDecor.zOffset, wallDecor.key, level, null);
 													} else if (wallDecor.secondary != null) {
 														if (GlRenderer.enabled) {
-															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 														}
 														wallDecor.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, local894, local899, local904, wallDecor.key, level, null);
 													}
@@ -1904,7 +1904,7 @@ public class SceneGraph {
 														GlRenderer.method4159(local33 + 50.0F - 1.5F);
 													}
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 													}
 													local1001.entity.render(0, pitchSin, pitchCos, yawSin, yawCos, local1001.xFine - cameraX, local1001.anInt733 - cameraY, local1001.zFine - cameraZ, local1001.key, level, null);
 													if (GlRenderer.enabled && local1001.aBoolean49) {
@@ -1914,7 +1914,7 @@ public class SceneGraph {
 												@Pc(1064) ObjStackEntity stackEntity = node.objStack;
 												if (stackEntity != null && stackEntity.minY == 0) {
 													if (GlRenderer.enabled) {
-														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 													}
 													if (stackEntity.secondary != null) {
 														stackEntity.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, stackEntity.xFine - cameraX, stackEntity.yFine - cameraY, stackEntity.zFine - cameraZ, stackEntity.key, level, null);
@@ -1930,25 +1930,25 @@ public class SceneGraph {
 											local894 = node.allInteriorFlags;
 											if (local894 != 0) {
 												if (nodeX < cameraTileX && (local894 & 0x4) != 0) {
-													var32 = levelTiles[nodeX + 1][nodeY];
+													var32 = levelTiles[nodeX + 1][nodeZ];
 													if (var32 != null && var32.aBoolean46) {
 														aClass69_32.addTail(var32);
 													}
 												}
-												if (nodeY < cameraTileZ && (local894 & 0x2) != 0) {
-													var32 = levelTiles[nodeX][nodeY + 1];
+												if (nodeZ < cameraTileZ && (local894 & 0x2) != 0) {
+													var32 = levelTiles[nodeX][nodeZ + 1];
 													if (var32 != null && var32.aBoolean46) {
 														aClass69_32.addTail(var32);
 													}
 												}
 												if (nodeX > cameraTileX && (local894 & 0x1) != 0) {
-													var32 = levelTiles[nodeX - 1][nodeY];
+													var32 = levelTiles[nodeX - 1][nodeZ];
 													if (var32 != null && var32.aBoolean46) {
 														aClass69_32.addTail(var32);
 													}
 												}
-												if (nodeY > cameraTileZ && (local894 & 0x8) != 0) {
-													var32 = levelTiles[nodeX][nodeY - 1];
+												if (nodeZ > cameraTileZ && (local894 & 0x8) != 0) {
+													var32 = levelTiles[nodeX][nodeZ - 1];
 													if (var32 != null && var32.aBoolean46) {
 														aClass69_32.addTail(var32);
 													}
@@ -1966,7 +1966,7 @@ public class SceneGraph {
 											}
 											if (var24) {
 												var22 = node.wall;
-												if (!method3850(plane, nodeX, nodeY, var22.anInt3049)) {
+												if (!method3850(plane, nodeX, nodeZ, var22.anInt3049)) {
 													if (GlRenderer.enabled) {
 														label882:
 														{
@@ -1977,34 +1977,34 @@ public class SceneGraph {
 																if (local1332 == 0) {
 																	sceneryIndex -= 64;
 																	local115 += 64;
-																	if (local115 < sceneryIndex && nodeX > 0 && nodeY < length - 1) {
-																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX - 1, nodeY + 1);
+																	if (local115 < sceneryIndex && nodeX > 0 && nodeZ < length - 1) {
+																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX - 1, nodeZ + 1);
 																		break label882;
 																	}
 																} else if (local1332 == 1) {
 																	sceneryIndex += 64;
 																	local115 += 64;
-																	if (local115 < -sceneryIndex && nodeX < width - 1 && nodeY < length - 1) {
-																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX + 1, nodeY + 1);
+																	if (local115 < -sceneryIndex && nodeX < width - 1 && nodeZ < length - 1) {
+																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX + 1, nodeZ + 1);
 																		break label882;
 																	}
 																} else if (local1332 == 2) {
 																	sceneryIndex += 64;
 																	local115 -= 64;
-																	if (local115 > sceneryIndex && nodeX < width - 1 && nodeY > 0) {
-																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX + 1, nodeY - 1);
+																	if (local115 > sceneryIndex && nodeX < width - 1 && nodeZ > 0) {
+																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX + 1, nodeZ - 1);
 																		break label882;
 																	}
 																} else if (local1332 == 3) {
 																	sceneryIndex -= 64;
 																	local115 -= 64;
-																	if (local115 > -sceneryIndex && nodeX > 0 && nodeY > 0) {
-																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX - 1, nodeY - 1);
+																	if (local115 > -sceneryIndex && nodeX > 0 && nodeZ > 0) {
+																		LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX - 1, nodeZ - 1);
 																		break label882;
 																	}
 																}
 															}
-															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 														}
 													}
 													var22.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, var22.xFine - cameraX, var22.anInt3051 - cameraY, var22.zFine - cameraZ, var22.key, level, null);
@@ -2094,20 +2094,20 @@ public class SceneGraph {
 												if (!method1599(plane, local1697.xMin, local1697.xMax, local1697.zMin, local1697.zMax, local1697.entity.getMinY())) {
 													if (GlRenderer.enabled) {
 														if ((local1697.key & 0xFC000L) == 147456L) {
-															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 															local894 = local1697.anInt1699 - cameraX;
 															local899 = local1697.anInt1703 - cameraZ;
 															local904 = (int) (local1697.key >> 20 & 0x3L);
 															if (local904 == 1 || local904 == 3) {
 																if (local899 > -local894) {
-																	LightingManager.method2397(level, nodeX, nodeY - 1, nodeX - 1, nodeY);
+																	LightingManager.method2397(level, nodeX, nodeZ - 1, nodeX - 1, nodeZ);
 																} else {
-																	LightingManager.method2397(level, nodeX, nodeY + 1, nodeX + 1, nodeY);
+																	LightingManager.method2397(level, nodeX, nodeZ + 1, nodeX + 1, nodeZ);
 																}
 															} else if (local899 > local894) {
-																LightingManager.method2397(level, nodeX, nodeY - 1, nodeX + 1, nodeY);
+																LightingManager.method2397(level, nodeX, nodeZ - 1, nodeX + 1, nodeZ);
 															} else {
-																LightingManager.method2397(level, nodeX, nodeY + 1, nodeX - 1, nodeY);
+																LightingManager.method2397(level, nodeX, nodeZ + 1, nodeX - 1, nodeZ);
 															}
 														} else {
 															LightingManager.method2391(cameraX, cameraY, cameraZ, level, local1697.xMin, local1697.zMin, local1697.xMax, local1697.zMax);
@@ -2120,7 +2120,7 @@ public class SceneGraph {
 														@Pc(1863) Tile local1863 = levelTiles[local894][local899];
 														if (local1863.anInt663 != 0) {
 															aClass69_32.addTail(local1863);
-														} else if ((local894 != nodeX || local899 != nodeY) && local1863.aBoolean46) {
+														} else if ((local894 != nodeX || local899 != nodeZ) && local1863.aBoolean46) {
 															aClass69_32.addTail(local1863);
 														}
 													}
@@ -2139,29 +2139,29 @@ public class SceneGraph {
 							if (nodeX > cameraTileX || nodeX <= LightingManager.anInt987) {
 								break;
 							}
-							local153 = levelTiles[nodeX - 1][nodeY];
+							local153 = levelTiles[nodeX - 1][nodeZ];
 						} while (local153 != null && local153.aBoolean46);
 						if (nodeX < cameraTileX || nodeX >= LightingManager.anInt15 - 1) {
 							break;
 						}
-						local153 = levelTiles[nodeX + 1][nodeY];
+						local153 = levelTiles[nodeX + 1][nodeZ];
 					} while (local153 != null && local153.aBoolean46);
-					if (nodeY > cameraTileZ || nodeY <= LightingManager.anInt4698) {
+					if (nodeZ > cameraTileZ || nodeZ <= LightingManager.anInt4698) {
 						break;
 					}
-					local153 = levelTiles[nodeX][nodeY - 1];
+					local153 = levelTiles[nodeX][nodeZ - 1];
 				} while (local153 != null && local153.aBoolean46);
-				if (nodeY < cameraTileZ || nodeY >= LightingManager.anInt4866 - 1) {
+				if (nodeZ < cameraTileZ || nodeZ >= LightingManager.anInt4866 - 1) {
 					break;
 				}
-				local153 = levelTiles[nodeX][nodeY + 1];
+				local153 = levelTiles[nodeX][nodeZ + 1];
 			} while (local153 != null && local153.aBoolean46);
 			node.aBoolean46 = false;
 			anInt1142--;
 			@Pc(1999) ObjStackEntity stackEntity = node.objStack;
 			if (stackEntity != null && stackEntity.minY != 0) {
 				if (GlRenderer.enabled) {
-					LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+					LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 				}
 				if (stackEntity.secondary != null) {
 					stackEntity.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, stackEntity.xFine - cameraX, stackEntity.yFine - cameraY - stackEntity.minY, stackEntity.zFine - cameraZ, stackEntity.key, level, null);
@@ -2175,10 +2175,10 @@ public class SceneGraph {
 			}
 			if (node.anInt670 != 0) {
 				@Pc(2109) WallDecor wallDecor = node.wallDecor;
-				if (wallDecor != null && !method4611(plane, nodeX, nodeY, wallDecor.primary.getMinY())) {
+				if (wallDecor != null && !method4611(plane, nodeX, nodeZ, wallDecor.primary.getMinY())) {
 					if ((wallDecor.anInt1395 & node.anInt670) != 0) {
 						if (GlRenderer.enabled) {
-							LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+							LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 						}
 						wallDecor.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, wallDecor.xFine + wallDecor.xOffset - cameraX, wallDecor.yFine - cameraY, wallDecor.zFine + wallDecor.zOffset - cameraZ, wallDecor.key, level, null);
 					} else if (wallDecor.anInt1395 == 256) {
@@ -2198,12 +2198,12 @@ public class SceneGraph {
 						}
 						if (local904 >= local899) {
 							if (GlRenderer.enabled) {
-								LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+								LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 							}
 							wallDecor.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, sceneryIndex + wallDecor.xOffset, local115, local1332 + wallDecor.zOffset, wallDecor.key, level, null);
 						} else if (wallDecor.secondary != null) {
 							if (GlRenderer.enabled) {
-								LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeY);
+								LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 							}
 							wallDecor.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, sceneryIndex, local115, local1332, wallDecor.key, level, null);
 						}
@@ -2211,15 +2211,15 @@ public class SceneGraph {
 				}
 				@Pc(2275) Wall local2275 = node.wall;
 				if (local2275 != null) {
-					if ((local2275.anInt3052 & node.anInt670) != 0 && !method3850(plane, nodeX, nodeY, local2275.anInt3052)) {
+					if ((local2275.anInt3052 & node.anInt670) != 0 && !method3850(plane, nodeX, nodeZ, local2275.anInt3052)) {
 						if (GlRenderer.enabled) {
-							LightingManager.method2388(local2275.anInt3052, cameraX, cameraY, cameraZ, plane, nodeX, nodeY);
+							LightingManager.method2388(local2275.anInt3052, cameraX, cameraY, cameraZ, plane, nodeX, nodeZ);
 						}
 						local2275.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, local2275.xFine - cameraX, local2275.anInt3051 - cameraY, local2275.zFine - cameraZ, local2275.key, level, null);
 					}
-					if ((local2275.anInt3049 & node.anInt670) != 0 && !method3850(plane, nodeX, nodeY, local2275.anInt3049)) {
+					if ((local2275.anInt3049 & node.anInt670) != 0 && !method3850(plane, nodeX, nodeZ, local2275.anInt3049)) {
 						if (GlRenderer.enabled) {
-							LightingManager.method2388(local2275.anInt3049, cameraX, cameraY, cameraZ, plane, nodeX, nodeY);
+							LightingManager.method2388(local2275.anInt3049, cameraX, cameraY, cameraZ, plane, nodeX, nodeZ);
 						}
 						local2275.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, local2275.xFine - cameraX, local2275.anInt3051 - cameraY, local2275.zFine - cameraZ, local2275.key, level, null);
 					}
@@ -2227,31 +2227,31 @@ public class SceneGraph {
 			}
 			@Pc(2388) Tile nextLevelTile;
 			if (level < levels - 1) {
-				nextLevelTile = tiles[level + 1][nodeX][nodeY];
+				nextLevelTile = tiles[level + 1][nodeX][nodeZ];
 				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
 					aClass69_32.addTail(nextLevelTile);
 				}
 			}
 			if (nodeX < cameraTileX) {
-				nextLevelTile = levelTiles[nodeX + 1][nodeY];
+				nextLevelTile = levelTiles[nodeX + 1][nodeZ];
 				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
 					aClass69_32.addTail(nextLevelTile);
 				}
 			}
-			if (nodeY < cameraTileZ) {
-				nextLevelTile = levelTiles[nodeX][nodeY + 1];
+			if (nodeZ < cameraTileZ) {
+				nextLevelTile = levelTiles[nodeX][nodeZ + 1];
 				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
 					aClass69_32.addTail(nextLevelTile);
 				}
 			}
 			if (nodeX > cameraTileX) {
-				nextLevelTile = levelTiles[nodeX - 1][nodeY];
+				nextLevelTile = levelTiles[nodeX - 1][nodeZ];
 				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
 					aClass69_32.addTail(nextLevelTile);
 				}
 			}
-			if (nodeY > cameraTileZ) {
-				nextLevelTile = levelTiles[nodeX][nodeY - 1];
+			if (nodeZ > cameraTileZ) {
+				nextLevelTile = levelTiles[nodeX][nodeZ - 1];
 				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
 					aClass69_32.addTail(nextLevelTile);
 				}
@@ -3204,13 +3204,13 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!fh", name = "a", descriptor = "(IIIILclient!th;JLclient!th;Lclient!th;)V")
-	public static void setObjStack(@OriginalArg(0) int level, @OriginalArg(1) int x, @OriginalArg(2) int z, @OriginalArg(3) int arg3, @OriginalArg(4) Entity primary, @OriginalArg(5) long arg5, @OriginalArg(6) Entity secondary, @OriginalArg(7) Entity tertiary) {
+	public static void setObjStack(@OriginalArg(0) int level, @OriginalArg(1) int x, @OriginalArg(2) int z, @OriginalArg(3) int y, @OriginalArg(4) Entity primary, @OriginalArg(5) long key, @OriginalArg(6) Entity secondary, @OriginalArg(7) Entity tertiary) {
 		@Pc(3) ObjStackEntity entity = new ObjStackEntity();
 		entity.primary = primary;
 		entity.xFine = x * 128 + 64;
 		entity.zFine = z * 128 + 64;
-		entity.yFine = arg3;
-		entity.key = arg5;
+		entity.yFine = y;
+		entity.key = key;
 		entity.secondary = secondary;
 		entity.tertiary = tertiary;
 		@Pc(34) int minEntityY = 0;
@@ -3291,19 +3291,19 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!s", name = "a", descriptor = "([[F[[B[[B[Lclient!gi;II[[F[[B[[B[[II[[F)V")
-	public static void method3393(@OriginalArg(0) float[][] arg0, @OriginalArg(1) byte[][] arg1, @OriginalArg(2) byte[][] arg2, @OriginalArg(3) Light[] arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5, @OriginalArg(6) float[][] arg6, @OriginalArg(7) byte[][] arg7, @OriginalArg(8) byte[][] arg8, @OriginalArg(9) int[][] arg9, @OriginalArg(11) float[][] arg10) {
-		for (@Pc(7) int local7 = 0; local7 < arg5; local7++) {
-			@Pc(18) Light local18 = arg3[local7];
-			if (local18.level == arg4) {
+	public static void method3393(@OriginalArg(0) float[][] arg0, @OriginalArg(1) byte[][] arg1, @OriginalArg(2) byte[][] arg2, @OriginalArg(3) Light[] lights, @OriginalArg(4) int level, @OriginalArg(5) int lightCount, @OriginalArg(6) float[][] arg6, @OriginalArg(7) byte[][] arg7, @OriginalArg(8) byte[][] arg8, @OriginalArg(9) int[][] arg9, @OriginalArg(11) float[][] arg10) {
+		for (@Pc(7) int i = 0; i < lightCount; i++) {
+			@Pc(18) Light light = lights[i];
+			if (light.level == level) {
 				@Pc(24) int local24 = 0;
 				@Pc(28) Light_Class45 local28 = new Light_Class45();
-				@Pc(37) int local37 = (local18.x >> 7) - local18.radius;
-				@Pc(46) int local46 = (local18.z >> 7) - local18.radius;
+				@Pc(37) int local37 = (light.x >> 7) - light.radius;
+				@Pc(46) int local46 = (light.z >> 7) - light.radius;
 				if (local46 < 0) {
 					local24 = -local46;
 					local46 = 0;
 				}
-				@Pc(65) int local65 = local18.radius + (local18.z >> 7);
+				@Pc(65) int local65 = light.radius + (light.z >> 7);
 				if (local65 > 103) {
 					local65 = 103;
 				}
@@ -3316,7 +3316,7 @@ public class SceneGraph {
 				@Pc(328) boolean local328;
 				@Pc(355) int local355;
 				for (local72 = local46; local72 <= local65; local72++) {
-					local84 = local18.aShortArray30[local24];
+					local84 = light.aShortArray30[local24];
 					local90 = local37 + (local84 >> 8);
 					local99 = local90 + (local84 & 0xFF) - 1;
 					if (local99 > 103) {
@@ -3363,7 +3363,7 @@ public class SceneGraph {
 								local135 = true;
 							}
 						}
-						@Pc(275) Scenery local275 = getScenery(arg4, local114, local72);
+						@Pc(275) Scenery local275 = getScenery(level, local114, local72);
 						if (local275 != null) {
 							@Pc(287) int local287 = (int) (local275.key >> 14) & 0x3F;
 							if (local287 == 9) {
@@ -3376,13 +3376,13 @@ public class SceneGraph {
 									local328 = local99 >= local114 + 1;
 									local315 = local114 - 1 >= local90;
 									if (!local315 && local72 + 1 <= local65) {
-										local343 = local18.aShortArray30[local24 + 1];
+										local343 = light.aShortArray30[local24 + 1];
 										local349 = local37 + (local343 >> 8);
 										local355 = local349 + (local343 & 0xFF);
 										local315 = local349 < local114 && local114 < local355;
 									}
 									if (!local328 && local72 - 1 >= local46) {
-										local343 = local18.aShortArray30[local24 - 1];
+										local343 = light.aShortArray30[local24 - 1];
 										local349 = local37 + (local343 >> 8);
 										local355 = local349 + (local343 & 0xFF);
 										local328 = local114 > local349 && local114 < local355;
@@ -3398,13 +3398,13 @@ public class SceneGraph {
 									local315 = local90 <= local114 - 1;
 									local328 = local114 + 1 <= local99;
 									if (!local315 && local72 - 1 >= local46) {
-										local343 = local18.aShortArray30[local24 - 1];
+										local343 = light.aShortArray30[local24 - 1];
 										local349 = (local343 >> 8) + local37;
 										local355 = local349 + (local343 & 0xFF);
 										local315 = local349 < local114 && local114 < local355;
 									}
 									if (!local328 && local72 + 1 <= local65) {
-										local343 = local18.aShortArray30[local24 + 1];
+										local343 = light.aShortArray30[local24 + 1];
 										local349 = (local343 >> 8) + local37;
 										local355 = local349 + (local343 & 0xFF);
 										local328 = local349 < local114 && local355 > local114;
@@ -3441,11 +3441,11 @@ public class SceneGraph {
 				}
 				local24 = 0;
 				local28.method1555();
-				if ((local18.z >> 7) - local18.radius < 0) {
-					local24 = local18.radius - (local18.z >> 7);
+				if ((light.z >> 7) - light.radius < 0) {
+					local24 = light.radius - (light.z >> 7);
 				}
 				for (local72 = local46; local72 <= local65; local72++) {
-					local84 = local18.aShortArray30[local24];
+					local84 = light.aShortArray30[local24];
 					local90 = (local84 >> 8) + local37;
 					local99 = (local84 & 0xFF) + local90 - 1;
 					if (local99 > 103) {
@@ -3469,13 +3469,13 @@ public class SceneGraph {
 								continue;
 							}
 							if (arg7[local114][local72] != 0) {
-								method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray35[arg7[local114][local72]], local28, local18, arg10, arg2[local114][local72]);
+								method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray35[arg7[local114][local72]], local28, light, arg10, arg2[local114][local72]);
 								continue;
 							}
 						} else if (local775 != 0) {
 							local805 = FloTypeList.method4395(local775 - 1);
 							if (local805.baseColor == -1) {
-								method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray8[arg7[local114][local72]], local28, local18, arg10, arg2[local114][local72]);
+								method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray8[arg7[local114][local72]], local28, light, arg10, arg2[local114][local72]);
 								continue;
 							}
 							@Pc(815) byte local815 = arg7[local114][local72];
@@ -3483,7 +3483,7 @@ public class SceneGraph {
 								local791 = true;
 							}
 						}
-						@Pc(899) Scenery local899 = getScenery(arg4, local114, local72);
+						@Pc(899) Scenery local899 = getScenery(level, local114, local72);
 						if (local899 != null) {
 							@Pc(911) int local911 = (int) (local899.key >> 14) & 0x3F;
 							if (local911 == 9) {
@@ -3496,13 +3496,13 @@ public class SceneGraph {
 									local328 = local114 - 1 >= local90;
 									local947 = local99 >= local114 + 1;
 									if (!local328 && local65 >= local72 + 1) {
-										local961 = local18.aShortArray30[local24 + 1];
+										local961 = light.aShortArray30[local24 + 1];
 										local355 = (local961 >> 8) + local37;
 										local973 = (local961 & 0xFF) + local355;
 										local328 = local114 > local355 && local973 > local114;
 									}
 									if (!local947 && local72 - 1 >= local46) {
-										local961 = local18.aShortArray30[local24 - 1];
+										local961 = light.aShortArray30[local24 - 1];
 										local355 = local37 + (local961 >> 8);
 										local973 = (local961 & 0xFF) + local355;
 										local947 = local355 < local114 && local973 > local114;
@@ -3520,13 +3520,13 @@ public class SceneGraph {
 									local328 = local114 - 1 >= local90;
 									local947 = local99 >= local114 + 1;
 									if (!local328 && local46 <= local72 - 1) {
-										local961 = local18.aShortArray30[local24 - 1];
+										local961 = light.aShortArray30[local24 - 1];
 										local355 = local37 + (local961 >> 8);
 										local973 = (local961 & 0xFF) + local355;
 										local328 = local114 > local355 && local973 > local114;
 									}
 									if (!local947 && local65 >= local72 + 1) {
-										local961 = local18.aShortArray30[local24 + 1];
+										local961 = light.aShortArray30[local24 + 1];
 										local355 = local37 + (local961 >> 8);
 										local973 = (local961 & 0xFF) + local355;
 										local947 = local114 > local355 && local973 > local114;
@@ -3542,23 +3542,23 @@ public class SceneGraph {
 									}
 								}
 								if (local917 != null) {
-									method2578(arg0, arg9, local114, arg6, local72, local917, local28, local18, arg10, local789);
+									method2578(arg0, arg9, local114, arg6, local72, local917, local28, light, arg10, local789);
 								}
 								continue;
 							}
 						}
 						if (local791) {
-							method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray8[arg7[local114][local72]], local28, local18, arg10, arg2[local114][local72]);
-							method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray35[arg7[local114][local72]], local28, local18, arg10, arg2[local114][local72]);
+							method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray8[arg7[local114][local72]], local28, light, arg10, arg2[local114][local72]);
+							method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray35[arg7[local114][local72]], local28, light, arg10, arg2[local114][local72]);
 						} else {
-							method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray35[0], local28, local18, arg10, local789);
+							method2578(arg0, arg9, local114, arg6, local72, anIntArrayArray35[0], local28, light, arg10, local789);
 						}
 					}
 					local24++;
 				}
 				if (local28.anInt2017 > 0 && local28.anInt2018 > 0) {
 					local28.method1554();
-					local18.aClass45_1 = local28;
+					light.aClass45_1 = local28;
 				}
 			}
 		}
@@ -5259,9 +5259,9 @@ public class SceneGraph {
 				} while (local515 <= 0);
 				for (local243 = 0; local243 < local515; local243++) {
 					@Pc(529) Light local529 = new Light(local95);
-					if (local529.anInt2243 == 31) {
-						@Pc(541) LightType local541 = LightTypeList.get(local95.g2());
-						local529.method1762(local541.anInt2865, local541.anInt2873, local541.anInt2867, local541.anInt2872);
+					if (local529.lightType == 31) {
+						@Pc(541) LightType lightType = LightTypeList.get(local95.g2());
+						local529.setUpLightType(lightType.flickerType, lightType.anInt2873, lightType.alphaMin, lightType.alphaMax);
 					}
 					local529.z += arg3 << 7;
 					local529.x += arg4 << 7;
@@ -5420,9 +5420,9 @@ public class SceneGraph {
 				} while (local497 <= 0);
 				for (local232 = 0; local232 < local497; local232++) {
 					@Pc(517) Light local517 = new Light(local96);
-					if (local517.anInt2243 == 31) {
-						@Pc(529) LightType local529 = LightTypeList.get(local96.g2());
-						local517.method1762(local529.anInt2865, local529.anInt2873, local529.anInt2867, local529.anInt2872);
+					if (local517.lightType == 31) {
+						@Pc(529) LightType lightType = LightTypeList.get(local96.g2());
+						local517.setUpLightType(lightType.flickerType, lightType.anInt2873, lightType.alphaMin, lightType.alphaMax);
 					}
 					local417 = local517.x >> 7;
 					local255 = local517.z >> 7;

--- a/client/src/main/java/rt4/SceneGraph.java
+++ b/client/src/main/java/rt4/SceneGraph.java
@@ -1709,25 +1709,25 @@ public class SceneGraph {
 														continue;
 													}
 												}
-												if (nodeX <= cameraTileX && nodeX > LightingManager.anInt987) {
+												if (nodeX <= cameraTileX && nodeX > LightingManager.minimumVisibleX) {
 													local153 = levelTiles[nodeX - 1][nodeZ];
 													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x1) == 0)) {
 														continue;
 													}
 												}
-												if (nodeX >= cameraTileX && nodeX < LightingManager.anInt15 - 1) {
+												if (nodeX >= cameraTileX && nodeX < LightingManager.maximumVisibleX - 1) {
 													local153 = levelTiles[nodeX + 1][nodeZ];
 													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x4) == 0)) {
 														continue;
 													}
 												}
-												if (nodeZ <= cameraTileZ && nodeZ > LightingManager.anInt4698) {
+												if (nodeZ <= cameraTileZ && nodeZ > LightingManager.minimumVisibleZ) {
 													local153 = levelTiles[nodeX][nodeZ - 1];
 													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x8) == 0)) {
 														continue;
 													}
 												}
-												if (nodeZ >= cameraTileZ && nodeZ < LightingManager.anInt4866 - 1) {
+												if (nodeZ >= cameraTileZ && nodeZ < LightingManager.maximumVisibleZ - 1) {
 													local153 = levelTiles[nodeX][nodeZ + 1];
 													if (local153 != null && local153.aBoolean46 && (local153.aBoolean45 || (node.allInteriorFlags & 0x2) == 0)) {
 														continue;
@@ -2136,22 +2136,22 @@ public class SceneGraph {
 									}
 								} while (!node.aBoolean46);
 							} while (node.anInt663 != 0);
-							if (nodeX > cameraTileX || nodeX <= LightingManager.anInt987) {
+							if (nodeX > cameraTileX || nodeX <= LightingManager.minimumVisibleX) {
 								break;
 							}
 							local153 = levelTiles[nodeX - 1][nodeZ];
 						} while (local153 != null && local153.aBoolean46);
-						if (nodeX < cameraTileX || nodeX >= LightingManager.anInt15 - 1) {
+						if (nodeX < cameraTileX || nodeX >= LightingManager.maximumVisibleX - 1) {
 							break;
 						}
 						local153 = levelTiles[nodeX + 1][nodeZ];
 					} while (local153 != null && local153.aBoolean46);
-					if (nodeZ > cameraTileZ || nodeZ <= LightingManager.anInt4698) {
+					if (nodeZ > cameraTileZ || nodeZ <= LightingManager.minimumVisibleZ) {
 						break;
 					}
 					local153 = levelTiles[nodeX][nodeZ - 1];
 				} while (local153 != null && local153.aBoolean46);
-				if (nodeZ < cameraTileZ || nodeZ >= LightingManager.anInt4866 - 1) {
+				if (nodeZ < cameraTileZ || nodeZ >= LightingManager.maximumVisibleZ - 1) {
 					break;
 				}
 				local153 = levelTiles[nodeX][nodeZ + 1];
@@ -2893,17 +2893,7 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!mf", name = "a", descriptor = "(IIIII[[[B[I[I[I[I[IIBII)V")
-	public static void method2954(@OriginalArg(0) int renderX, @OriginalArg(1) int renderY, @OriginalArg(2) int renderZ, @OriginalArg(3) int cameraPitch, @OriginalArg(4) int cameraYaw, @OriginalArg(5) byte[][][] arg5, @OriginalArg(6) int[] arg6, @OriginalArg(7) int[] arg7, @OriginalArg(8) int[] arg8, @OriginalArg(9) int[] arg9, @OriginalArg(10) int[] arg10, @OriginalArg(11) int level, @OriginalArg(12) byte arg12, @OriginalArg(13) int centerX, @OriginalArg(14) int centerZ) {
-		if (renderX < 0) {
-			renderX = 0;
-		} else if (renderX >= width * 128) {
-			renderX = width * 128 - 1;
-		}
-		if (renderZ < 0) {
-			renderZ = 0;
-		} else if (renderZ >= length * 128) {
-			renderZ = length * 128 - 1;
-		}
+	public static void method2954(@OriginalArg(0) int renderX, @OriginalArg(1) int renderY, @OriginalArg(2) int renderZ, @OriginalArg(3) int cameraPitch, @OriginalArg(4) int cameraYaw, @OriginalArg(5) byte[][][] removeRoofTiles, @OriginalArg(6) int[] arg6, @OriginalArg(7) int[] arg7, @OriginalArg(8) int[] arg8, @OriginalArg(9) int[] arg9, @OriginalArg(10) int[] arg10, @OriginalArg(11) int level, @OriginalArg(12) byte arg12, @OriginalArg(13) int centerX, @OriginalArg(14) int centerZ) {
 		pitchSin = MathUtils.sin[cameraPitch];
 		pitchCos = MathUtils.cos[cameraPitch];
 		yawSin = MathUtils.sin[cameraYaw];
@@ -2913,36 +2903,36 @@ public class SceneGraph {
 		cameraZ = renderZ;
 		cameraTileX = renderX / 128;
 		cameraTileZ = renderZ / 128;
-		LightingManager.anInt987 = cameraTileX - visibility;
-		if (LightingManager.anInt987 < 0) {
-			LightingManager.anInt987 = 0;
+		LightingManager.minimumVisibleX = cameraTileX - visibility;
+		if (LightingManager.minimumVisibleX < 0) {
+			LightingManager.minimumVisibleX = 0;
 		}
-		LightingManager.anInt4698 = cameraTileZ - visibility;
-		if (LightingManager.anInt4698 < 0) {
-			LightingManager.anInt4698 = 0;
+		LightingManager.minimumVisibleZ = cameraTileZ - visibility;
+		if (LightingManager.minimumVisibleZ < 0) {
+			LightingManager.minimumVisibleZ = 0;
 		}
-		LightingManager.anInt15 = cameraTileX + visibility;
-		if (LightingManager.anInt15 > width) {
-			LightingManager.anInt15 = width;
+		LightingManager.maximumVisibleX = cameraTileX + visibility;
+		if (LightingManager.maximumVisibleX > width) {
+			LightingManager.maximumVisibleX = width;
 		}
-		LightingManager.anInt4866 = cameraTileZ + visibility;
-		if (LightingManager.anInt4866 > length) {
-			LightingManager.anInt4866 = length;
+		LightingManager.maximumVisibleZ = cameraTileZ + visibility;
+		if (LightingManager.maximumVisibleZ > length) {
+			LightingManager.maximumVisibleZ = length;
 		}
-		@Pc(99) short local99;
+		@Pc(99) short viewDistance;
 		if (GlRenderer.enabled) {
-			local99 = (short) GlobalConfig.VIEW_DISTANCE;
+			viewDistance = (short) GlobalConfig.VIEW_DISTANCE;
 		} else {
-			local99 = 3500;
+			viewDistance = 3500;
 		}
-		@Pc(104) int local104;
-		@Pc(113) int local113;
-		for (local104 = 0; local104 < visibility + visibility + 2; local104++) {
-			for (local113 = 0; local113 < visibility + visibility + 2; local113++) {
-				@Pc(130) int local130 = (local104 - visibility << 7) - (cameraX & 0x7F);
-				@Pc(140) int local140 = (local113 - visibility << 7) - (cameraZ & 0x7F);
-				@Pc(146) int local146 = cameraTileX + local104 - visibility;
-				@Pc(152) int local152 = cameraTileZ + local113 - visibility;
+		@Pc(104) int xFine;
+		@Pc(113) int zFine;
+		for (xFine = 0; xFine < visibility + visibility + 2; xFine++) {
+			for (zFine = 0; zFine < visibility + visibility + 2; zFine++) {
+				@Pc(130) int local130 = (xFine - visibility << 7) - (cameraX & 0x7F);
+				@Pc(140) int local140 = (zFine - visibility << 7) - (cameraZ & 0x7F);
+				@Pc(146) int local146 = cameraTileX + xFine - visibility;
+				@Pc(152) int local152 = cameraTileZ + zFine - visibility;
 				if (local146 >= 0 && local152 >= 0 && local146 < width && local152 < length) {
 					@Pc(176) int local176;
 					if (underwaterTileHeights == null) {
@@ -2951,15 +2941,15 @@ public class SceneGraph {
 						local176 = underwaterTileHeights[0][local146][local152] + 128 - cameraY;
 					}
 					@Pc(201) int local201 = surfaceTileHeights[3][local146][local152] - cameraY - 1000;
-					aBooleanArrayArray3[local104][local113] = method3049(local130, local201, local176, local140, local99);
+					aBooleanArrayArray3[xFine][zFine] = method3049(local130, local201, local176, local140, viewDistance);
 				} else {
-					aBooleanArrayArray3[local104][local113] = false;
+					aBooleanArrayArray3[xFine][zFine] = false;
 				}
 			}
 		}
-		for (local104 = 0; local104 < visibility + visibility + 1; local104++) {
-			for (local113 = 0; local113 < visibility + visibility + 1; local113++) {
-				aBooleanArrayArray1[local104][local113] = aBooleanArrayArray3[local104][local113] || aBooleanArrayArray3[local104 + 1][local113] || aBooleanArrayArray3[local104][local113 + 1] || aBooleanArrayArray3[local104 + 1][local113 + 1];
+		for (xFine = 0; xFine < visibility + visibility + 1; xFine++) {
+			for (zFine = 0; zFine < visibility + visibility + 1; zFine++) {
+				aBooleanArrayArray1[xFine][zFine] = aBooleanArrayArray3[xFine][zFine] || aBooleanArrayArray3[xFine + 1][zFine] || aBooleanArrayArray3[xFine][zFine + 1] || aBooleanArrayArray3[xFine + 1][zFine + 1];
 			}
 		}
 		anIntArray8 = arg6;
@@ -2967,23 +2957,23 @@ public class SceneGraph {
 		anIntArray234 = arg8;
 		anIntArray454 = arg9;
 		anIntArray427 = arg10;
-		method2419();
-		if (underWaterGroundTiles != null) {
-			setUnderwater(true);
-			method3292(renderX, renderY, renderZ, null, 0, (byte) 0, centerX, centerZ);
-			if (GlRenderer.enabled) {
-				MaterialManager.renderingUnderwater = false;
-				MaterialManager.setMaterial(0, 0);
-				FogManager.setFogColor(null);
-				LightingManager.method2390();
-			}
-			setUnderwater(false);
-		}
-		method3292(renderX, renderY, renderZ, arg5, level, arg12, centerX, centerZ);
-	}
+        method2419();
+        if (underWaterGroundTiles != null) {
+            setUnderwater(true);
+            method3292(renderX, renderY, renderZ, null, 0, (byte) 0, centerX, centerZ);
+            if (GlRenderer.enabled) {
+                MaterialManager.renderingUnderwater = false;
+                MaterialManager.setMaterial(0, 0);
+                FogManager.setFogColor(null);
+                LightingManager.method2390();
+            }
+            setUnderwater(false);
+        }
+        method3292(renderX, renderY, renderZ, removeRoofTiles, level, arg12, centerX, centerZ);
+    }
 
 	@OriginalMember(owner = "client!uc", name = "a", descriptor = "(III[[[BIBII)V")
-	public static void method3292(@OriginalArg(0) int renderX, @OriginalArg(1) int renderY, @OriginalArg(2) int renderZ, @OriginalArg(3) byte[][][] arg3, @OriginalArg(4) int arg4, @OriginalArg(5) byte arg5, @OriginalArg(6) int centerX, @OriginalArg(7) int centerZ) {
+	public static void method3292(@OriginalArg(0) int renderX, @OriginalArg(1) int renderY, @OriginalArg(2) int renderZ, @OriginalArg(3) byte[][][] removeRoofTiles, @OriginalArg(4) int arg4, @OriginalArg(5) byte arg5, @OriginalArg(6) int centerX, @OriginalArg(7) int centerZ) {
 		anInt437++;
 		anInt1142 = 0;
 		@Pc(9) int local9 = centerX - 16;
@@ -2993,13 +2983,13 @@ public class SceneGraph {
 		@Pc(32) int x;
 		@Pc(37) int z;
 		@Pc(183) int local183;
-		for (@Pc(23) int level = firstVisibleLevel; level < levels; level++) {
-			@Pc(30) Tile[][] levelTiles = tiles[level];
-			for (x = LightingManager.anInt987; x < LightingManager.anInt15; x++) {
-				for (z = LightingManager.anInt4698; z < LightingManager.anInt4866; z++) {
+		for (@Pc(23) int currentLevel = firstVisibleLevel; currentLevel < levels; currentLevel++) {
+			@Pc(30) Tile[][] levelTiles = tiles[currentLevel];
+			for (x = LightingManager.minimumVisibleX; x < LightingManager.maximumVisibleX; x++) {
+				for (z = LightingManager.minimumVisibleZ; z < LightingManager.maximumVisibleZ; z++) {
 					@Pc(46) Tile local46 = levelTiles[x][z];
 					if (local46 != null) {
-						if (aBooleanArrayArray1[x + visibility - cameraTileX][z + visibility - cameraTileZ] && (arg3 == null || level < arg4 || arg3[level][x][z] != arg5)) {
+						if (aBooleanArrayArray1[x + visibility - cameraTileX][z + visibility - cameraTileZ] && (removeRoofTiles == null || currentLevel < arg4 || removeRoofTiles[currentLevel][x][z] != arg5)) {
 							local46.aBoolean45 = true;
 							local46.aBoolean46 = true;
 							local46.aBoolean47 = local46.sceneryLen > 0;
@@ -3011,26 +3001,26 @@ public class SceneGraph {
 							if (x >= local9 && x <= local13 && z >= local17 && z <= local21) {
 								if (local46.wall != null) {
 									@Pc(103) Wall local103 = local46.wall;
-									local103.primary.method4545(0, level, local103.anInt3051, local103.xFine, local103.zFine);
+									local103.primary.method4545(0, currentLevel, local103.anInt3051, local103.xFine, local103.zFine);
 									if (local103.secondary != null) {
-										local103.secondary.method4545(0, level, local103.anInt3051, local103.xFine, local103.zFine);
+										local103.secondary.method4545(0, currentLevel, local103.anInt3051, local103.xFine, local103.zFine);
 									}
 								}
 								if (local46.wallDecor != null) {
 									@Pc(134) WallDecor local134 = local46.wallDecor;
-									local134.primary.method4545(local134.anInt1388, level, local134.yFine, local134.xFine, local134.zFine);
+									local134.primary.method4545(local134.anInt1388, currentLevel, local134.yFine, local134.xFine, local134.zFine);
 									if (local134.secondary != null) {
-										local134.secondary.method4545(local134.anInt1388, level, local134.yFine, local134.xFine, local134.zFine);
+										local134.secondary.method4545(local134.anInt1388, currentLevel, local134.yFine, local134.xFine, local134.zFine);
 									}
 								}
 								if (local46.groundDecor != null) {
 									@Pc(167) GroundDecor local167 = local46.groundDecor;
-									local167.entity.method4545(0, level, local167.anInt733, local167.xFine, local167.zFine);
+									local167.entity.method4545(0, currentLevel, local167.anInt733, local167.xFine, local167.zFine);
 								}
 								if (local46.scenery != null) {
 									for (local183 = 0; local183 < local46.sceneryLen; local183++) {
 										@Pc(192) Scenery local192 = local46.scenery[local183];
-										local192.entity.method4545(local192.anInt1714, level, local192.anInt1706, local192.anInt1699, local192.anInt1703);
+										local192.entity.method4545(local192.anInt1714, currentLevel, local192.anInt1706, local192.anInt1699, local192.anInt1703);
 									}
 								}
 							}
@@ -3088,45 +3078,45 @@ public class SceneGraph {
 		}
 		@Pc(434) int local434;
 		@Pc(438) int local438;
-		@Pc(450) Tile local450;
-		@Pc(399) int level;
+		@Pc(450) Tile tileToRender;
+		@Pc(399) int l;
 		@Pc(406) Tile[][] levelTiles;
 		@Pc(415) int local415;
 		@Pc(428) int local428;
-		for (level = firstVisibleLevel; level < levels; level++) {
-			levelTiles = tiles[level];
+		for (l = firstVisibleLevel; l < levels; l++) {
+			levelTiles = tiles[l];
 			for (z = -visibility; z <= 0; z++) {
 				local415 = cameraTileX + z;
 				local183 = cameraTileX - z;
-				if (local415 >= LightingManager.anInt987 || local183 < LightingManager.anInt15) {
+				if (local415 >= LightingManager.minimumVisibleX || local183 < LightingManager.maximumVisibleX) {
 					for (local428 = -visibility; local428 <= 0; local428++) {
 						local434 = cameraTileZ + local428;
 						local438 = cameraTileZ - local428;
-						if (local415 >= LightingManager.anInt987) {
-							if (local434 >= LightingManager.anInt4698) {
-								local450 = levelTiles[local415][local434];
-								if (local450 != null && local450.aBoolean45) {
-									method4245(local450, true);
+						if (local415 >= LightingManager.minimumVisibleX) {
+							if (local434 >= LightingManager.minimumVisibleZ) {
+								tileToRender = levelTiles[local415][local434];
+								if (tileToRender != null && tileToRender.aBoolean45) {
+									method4245(tileToRender, true);
 								}
 							}
-							if (local438 < LightingManager.anInt4866) {
-								local450 = levelTiles[local415][local438];
-								if (local450 != null && local450.aBoolean45) {
-									method4245(local450, true);
+							if (local438 < LightingManager.maximumVisibleZ) {
+								tileToRender = levelTiles[local415][local438];
+								if (tileToRender != null && tileToRender.aBoolean45) {
+									method4245(tileToRender, true);
 								}
 							}
 						}
-						if (local183 < LightingManager.anInt15) {
-							if (local434 >= LightingManager.anInt4698) {
-								local450 = levelTiles[local183][local434];
-								if (local450 != null && local450.aBoolean45) {
-									method4245(local450, true);
+						if (local183 < LightingManager.maximumVisibleX) {
+							if (local434 >= LightingManager.minimumVisibleZ) {
+								tileToRender = levelTiles[local183][local434];
+								if (tileToRender != null && tileToRender.aBoolean45) {
+									method4245(tileToRender, true);
 								}
 							}
-							if (local438 < LightingManager.anInt4866) {
-								local450 = levelTiles[local183][local438];
-								if (local450 != null && local450.aBoolean45) {
-									method4245(local450, true);
+							if (local438 < LightingManager.maximumVisibleZ) {
+								tileToRender = levelTiles[local183][local438];
+								if (tileToRender != null && tileToRender.aBoolean45) {
+									method4245(tileToRender, true);
 								}
 							}
 						}
@@ -3140,41 +3130,40 @@ public class SceneGraph {
 				}
 			}
 		}
-		for (level = firstVisibleLevel; level < levels; level++) {
-			levelTiles = tiles[level];
+		for (l = firstVisibleLevel; l < levels; l++) {
+			levelTiles = tiles[l];
 			for (z = -visibility; z <= 0; z++) {
 				local415 = cameraTileX + z;
 				local183 = cameraTileX - z;
-
-				if (local415 >= LightingManager.anInt987 || local183 < LightingManager.anInt15) {
+				if (local415 >= LightingManager.minimumVisibleX || local183 < LightingManager.maximumVisibleX) {
 					for (local428 = -visibility; local428 <= 0; local428++) {
 						local434 = cameraTileZ + local428;
 						local438 = cameraTileZ - local428;
-						if (local415 >= LightingManager.anInt987) {
-							if (local434 >= LightingManager.anInt4698) {
-								local450 = levelTiles[local415][local434];
-								if (local450 != null && local450.aBoolean45) {
-									method4245(local450, false);
+						if (local415 >= LightingManager.minimumVisibleX) {
+							if (local434 >= LightingManager.minimumVisibleZ) {
+								tileToRender = levelTiles[local415][local434];
+								if (tileToRender != null && tileToRender.aBoolean45) {
+									method4245(tileToRender, false);
 								}
 							}
-							if (local438 < LightingManager.anInt4866) {
-								local450 = levelTiles[local415][local438];
-								if (local450 != null && local450.aBoolean45) {
-									method4245(local450, false);
+							if (local438 < LightingManager.maximumVisibleZ) {
+								tileToRender = levelTiles[local415][local438];
+								if (tileToRender != null && tileToRender.aBoolean45) {
+									method4245(tileToRender, false);
 								}
 							}
 						}
-						if (local183 < LightingManager.anInt15) {
-							if (local434 >= LightingManager.anInt4698) {
-								local450 = levelTiles[local183][local434];
-								if (local450 != null && local450.aBoolean45) {
-									method4245(local450, false);
+						if (local183 < LightingManager.maximumVisibleX) {
+							if (local434 >= LightingManager.minimumVisibleZ) {
+								tileToRender = levelTiles[local183][local434];
+								if (tileToRender != null && tileToRender.aBoolean45) {
+									method4245(tileToRender, false);
 								}
 							}
-							if (local438 < LightingManager.anInt4866) {
-								local450 = levelTiles[local183][local438];
-								if (local450 != null && local450.aBoolean45) {
-									method4245(local450, false);
+							if (local438 < LightingManager.maximumVisibleZ) {
+								tileToRender = levelTiles[local183][local438];
+								if (tileToRender != null && tileToRender.aBoolean45) {
+									method4245(tileToRender, false);
 								}
 							}
 						}
@@ -3976,7 +3965,7 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!mj", name = "a", descriptor = "(IIIII)Z")
-	public static boolean method3049(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
+	public static boolean method3049(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int viewDistance) {
 		@Pc(9) int local9 = arg3 * yawSin + arg0 * yawCos >> 16;
 		@Pc(19) int local19 = arg3 * yawCos - arg0 * yawSin >> 16;
 		@Pc(29) int local29 = arg1 * pitchSin + local19 * pitchCos >> 16;
@@ -3995,7 +3984,7 @@ public class SceneGraph {
 		@Pc(93) int local93 = (local76 << 9) / local66;
 		if (local29 < 50 && local66 < 50) {
 			return false;
-		} else if (local29 > arg4 && local66 > arg4) {
+		} else if (local29 > viewDistance && local66 > viewDistance) {
 			return false;
 		} else if (local50 < Rasteriser.screenLowerX && local87 < Rasteriser.screenLowerX) {
 			return false;

--- a/client/src/main/java/rt4/SceneGraph.java
+++ b/client/src/main/java/rt4/SceneGraph.java
@@ -54,7 +54,7 @@ public class SceneGraph {
 	@OriginalMember(owner = "client!fg", name = "t", descriptor = "[I")
 	public static final int[] anIntArray170 = new int[6];
 	@OriginalMember(owner = "client!ah", name = "p", descriptor = "Lclient!ih;")
-	public static final LinkedList aClass69_32 = new LinkedList();
+	public static final LinkedList tileRenderStack = new LinkedList();
 	@OriginalMember(owner = "client!sh", name = "i", descriptor = "[[I")
 	public static final int[][] anIntArrayArray35 = new int[][]{{0, 128, 0, 0, 128, 0, 128, 128}, {0, 128, 0, 0, 128, 0}, {0, 0, 64, 128, 0, 128}, {128, 128, 64, 128, 128, 0}, {0, 0, 128, 0, 128, 128, 64, 128}, {0, 128, 0, 0, 128, 0, 64, 128}, {64, 128, 0, 128, 0, 0, 64, 0}, {0, 0, 64, 0, 0, 64}, {128, 0, 128, 128, 0, 128, 0, 64, 64, 0}, {0, 128, 0, 0, 32, 64, 64, 96, 128, 128}, {0, 0, 128, 0, 128, 128, 64, 96, 32, 64}, {0, 0, 128, 0, 96, 32, 32, 32}};
 	@OriginalMember(owner = "client!gf", name = "S", descriptor = "[I")
@@ -1632,8 +1632,8 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!ub", name = "a", descriptor = "(Lclient!bj;Z)V")
-	public static void method4245(@OriginalArg(0) Tile arg0, @OriginalArg(1) boolean arg1) {
-		aClass69_32.addTail(arg0);
+	public static void addTileToRenderStack(@OriginalArg(0) Tile tile, @OriginalArg(1) boolean arg1) {
+		tileRenderStack.addTail(tile);
 		while (true) {
 			@Pc(8) Tile node;
 			@Pc(18) int nodeX;
@@ -1665,7 +1665,7 @@ public class SceneGraph {
 										@Pc(1179) Tile var32;
 										while (true) {
 											do {
-												node = (Tile) aClass69_32.removeHead();
+												node = (Tile) tileRenderStack.removeHead();
 												if (node == null) {
 													return;
 												}
@@ -1932,25 +1932,25 @@ public class SceneGraph {
 												if (nodeX < cameraTileX && (local894 & 0x4) != 0) {
 													var32 = levelTiles[nodeX + 1][nodeZ];
 													if (var32 != null && var32.aBoolean46) {
-														aClass69_32.addTail(var32);
+														tileRenderStack.addTail(var32);
 													}
 												}
 												if (nodeZ < cameraTileZ && (local894 & 0x2) != 0) {
 													var32 = levelTiles[nodeX][nodeZ + 1];
 													if (var32 != null && var32.aBoolean46) {
-														aClass69_32.addTail(var32);
+														tileRenderStack.addTail(var32);
 													}
 												}
 												if (nodeX > cameraTileX && (local894 & 0x1) != 0) {
 													var32 = levelTiles[nodeX - 1][nodeZ];
 													if (var32 != null && var32.aBoolean46) {
-														aClass69_32.addTail(var32);
+														tileRenderStack.addTail(var32);
 													}
 												}
 												if (nodeZ > cameraTileZ && (local894 & 0x8) != 0) {
 													var32 = levelTiles[nodeX][nodeZ - 1];
 													if (var32 != null && var32.aBoolean46) {
-														aClass69_32.addTail(var32);
+														tileRenderStack.addTail(var32);
 													}
 												}
 											}
@@ -2119,9 +2119,9 @@ public class SceneGraph {
 													for (local899 = local1697.zMin; local899 <= local1697.zMax; local899++) {
 														@Pc(1863) Tile local1863 = levelTiles[local894][local899];
 														if (local1863.anInt663 != 0) {
-															aClass69_32.addTail(local1863);
+															tileRenderStack.addTail(local1863);
 														} else if ((local894 != nodeX || local899 != nodeZ) && local1863.aBoolean46) {
-															aClass69_32.addTail(local1863);
+															tileRenderStack.addTail(local1863);
 														}
 													}
 												}
@@ -2225,35 +2225,35 @@ public class SceneGraph {
 					}
 				}
 			}
-			@Pc(2388) Tile nextLevelTile;
+			@Pc(2388) Tile tileToTail;
 			if (level < levels - 1) {
-				nextLevelTile = tiles[level + 1][nodeX][nodeZ];
-				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
-					aClass69_32.addTail(nextLevelTile);
+				tileToTail = tiles[level + 1][nodeX][nodeZ];
+				if (tileToTail != null && tileToTail.aBoolean46) {
+					tileRenderStack.addTail(tileToTail);
 				}
 			}
 			if (nodeX < cameraTileX) {
-				nextLevelTile = levelTiles[nodeX + 1][nodeZ];
-				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
-					aClass69_32.addTail(nextLevelTile);
+				tileToTail = levelTiles[nodeX + 1][nodeZ];
+				if (tileToTail != null && tileToTail.aBoolean46) {
+					tileRenderStack.addTail(tileToTail);
 				}
 			}
 			if (nodeZ < cameraTileZ) {
-				nextLevelTile = levelTiles[nodeX][nodeZ + 1];
-				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
-					aClass69_32.addTail(nextLevelTile);
+				tileToTail = levelTiles[nodeX][nodeZ + 1];
+				if (tileToTail != null && tileToTail.aBoolean46) {
+					tileRenderStack.addTail(tileToTail);
 				}
 			}
 			if (nodeX > cameraTileX) {
-				nextLevelTile = levelTiles[nodeX - 1][nodeZ];
-				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
-					aClass69_32.addTail(nextLevelTile);
+				tileToTail = levelTiles[nodeX - 1][nodeZ];
+				if (tileToTail != null && tileToTail.aBoolean46) {
+					tileRenderStack.addTail(tileToTail);
 				}
 			}
 			if (nodeZ > cameraTileZ) {
-				nextLevelTile = levelTiles[nodeX][nodeZ - 1];
-				if (nextLevelTile != null && nextLevelTile.aBoolean46) {
-					aClass69_32.addTail(nextLevelTile);
+				tileToTail = levelTiles[nodeX][nodeZ - 1];
+				if (tileToTail != null && tileToTail.aBoolean46) {
+					tileRenderStack.addTail(tileToTail);
 				}
 			}
 		}
@@ -2904,20 +2904,20 @@ public class SceneGraph {
 		cameraTileX = renderX / 128;
 		cameraTileZ = renderZ / 128;
 		LightingManager.minimumVisibleX = cameraTileX - visibility;
-		if (LightingManager.minimumVisibleX < 0) {
-			LightingManager.minimumVisibleX = 0;
+		if (LightingManager.minimumVisibleX <= 0) {
+			LightingManager.minimumVisibleX = 1;
 		}
 		LightingManager.minimumVisibleZ = cameraTileZ - visibility;
-		if (LightingManager.minimumVisibleZ < 0) {
-			LightingManager.minimumVisibleZ = 0;
+		if (LightingManager.minimumVisibleZ <= 0) {
+			LightingManager.minimumVisibleZ = 1;
 		}
 		LightingManager.maximumVisibleX = cameraTileX + visibility;
-		if (LightingManager.maximumVisibleX > width) {
-			LightingManager.maximumVisibleX = width;
+		if (LightingManager.maximumVisibleX >= width) {
+			LightingManager.maximumVisibleX = width - 1;
 		}
 		LightingManager.maximumVisibleZ = cameraTileZ + visibility;
-		if (LightingManager.maximumVisibleZ > length) {
-			LightingManager.maximumVisibleZ = length;
+		if (LightingManager.maximumVisibleZ >= length) {
+			LightingManager.maximumVisibleZ = length - 1;
 		}
 		@Pc(99) short viewDistance;
 		if (GlRenderer.enabled) {
@@ -2982,44 +2982,43 @@ public class SceneGraph {
 		@Pc(21) int local21 = centerZ + 16;
 		@Pc(32) int x;
 		@Pc(37) int z;
-		@Pc(183) int local183;
 		for (@Pc(23) int currentLevel = firstVisibleLevel; currentLevel < levels; currentLevel++) {
 			@Pc(30) Tile[][] levelTiles = tiles[currentLevel];
 			for (x = LightingManager.minimumVisibleX; x < LightingManager.maximumVisibleX; x++) {
 				for (z = LightingManager.minimumVisibleZ; z < LightingManager.maximumVisibleZ; z++) {
-					@Pc(46) Tile local46 = levelTiles[x][z];
-					if (local46 != null) {
+					@Pc(46) Tile tile = levelTiles[x][z];
+					if (tile != null) {
 						if (aBooleanArrayArray1[x + visibility - cameraTileX][z + visibility - cameraTileZ] && (removeRoofTiles == null || currentLevel < arg4 || removeRoofTiles[currentLevel][x][z] != arg5)) {
-							local46.aBoolean45 = true;
-							local46.aBoolean46 = true;
-							local46.aBoolean47 = local46.sceneryLen > 0;
+							tile.aBoolean45 = true;
+							tile.aBoolean46 = true;
+							tile.aBoolean47 = tile.sceneryLen > 0;
 							anInt1142++;
 						} else {
-							local46.aBoolean45 = false;
-							local46.aBoolean46 = false;
-							local46.anInt663 = 0;
+							tile.aBoolean45 = false;
+							tile.aBoolean46 = false;
+							tile.anInt663 = 0;
 							if (x >= local9 && x <= local13 && z >= local17 && z <= local21) {
-								if (local46.wall != null) {
-									@Pc(103) Wall local103 = local46.wall;
-									local103.primary.method4545(0, currentLevel, local103.anInt3051, local103.xFine, local103.zFine);
-									if (local103.secondary != null) {
-										local103.secondary.method4545(0, currentLevel, local103.anInt3051, local103.xFine, local103.zFine);
+								if (tile.wall != null) {
+									@Pc(103) Wall wall = tile.wall;
+									wall.primary.method4545(0, currentLevel, wall.anInt3051, wall.xFine, wall.zFine);
+									if (wall.secondary != null) {
+										wall.secondary.method4545(0, currentLevel, wall.anInt3051, wall.xFine, wall.zFine);
 									}
 								}
-								if (local46.wallDecor != null) {
-									@Pc(134) WallDecor local134 = local46.wallDecor;
-									local134.primary.method4545(local134.anInt1388, currentLevel, local134.yFine, local134.xFine, local134.zFine);
-									if (local134.secondary != null) {
-										local134.secondary.method4545(local134.anInt1388, currentLevel, local134.yFine, local134.xFine, local134.zFine);
+								if (tile.wallDecor != null) {
+									@Pc(134) WallDecor wallDecor = tile.wallDecor;
+									wallDecor.primary.method4545(wallDecor.anInt1388, currentLevel, wallDecor.yFine, wallDecor.xFine, wallDecor.zFine);
+									if (wallDecor.secondary != null) {
+										wallDecor.secondary.method4545(wallDecor.anInt1388, currentLevel, wallDecor.yFine, wallDecor.xFine, wallDecor.zFine);
 									}
 								}
-								if (local46.groundDecor != null) {
-									@Pc(167) GroundDecor local167 = local46.groundDecor;
-									local167.entity.method4545(0, currentLevel, local167.anInt733, local167.xFine, local167.zFine);
+								if (tile.groundDecor != null) {
+									@Pc(167) GroundDecor groundDecor = tile.groundDecor;
+									groundDecor.entity.method4545(0, currentLevel, groundDecor.anInt733, groundDecor.xFine, groundDecor.zFine);
 								}
-								if (local46.scenery != null) {
-									for (local183 = 0; local183 < local46.sceneryLen; local183++) {
-										@Pc(192) Scenery local192 = local46.scenery[local183];
+								if (tile.scenery != null) {
+									for (int i = 0; i < tile.sceneryLen; i++) {
+										@Pc(192) Scenery local192 = tile.scenery[i];
 										local192.entity.method4545(local192.anInt1714, currentLevel, local192.anInt1706, local192.anInt1699, local192.anInt1703);
 									}
 								}
@@ -3029,12 +3028,12 @@ public class SceneGraph {
 				}
 			}
 		}
-		@Pc(240) boolean local240 = tileHeights == underwaterTileHeights;
+		@Pc(240) boolean heights = tileHeights == underwaterTileHeights;
 		if (GlRenderer.enabled) {
 			@Pc(244) GL2 gl = GlRenderer.gl;
 			gl.glPushMatrix();
 			gl.glTranslatef((float) -renderX, (float) -renderY, (float) -renderZ);
-			if (local240) {
+			if (heights) {
 				UnderwaterMaterialRenderer.applyFogFade();
 				MaterialManager.setMaterial(-1, 3);
 				MaterialManager.renderingUnderwater = true;
@@ -3076,57 +3075,70 @@ public class SceneGraph {
 			}
 			gl.glPopMatrix();
 		}
-		@Pc(434) int local434;
-		@Pc(438) int local438;
+		@Pc(434) int positiveZEdge;
+		@Pc(438) int negativeZEdge;
 		@Pc(450) Tile tileToRender;
 		@Pc(399) int l;
 		@Pc(406) Tile[][] levelTiles;
-		@Pc(415) int local415;
-		@Pc(428) int local428;
+		@Pc(415) int positiveXEdge;
+		int negativeXEdge;
+		@Pc(428) int worldX;
+		int worldZ;
 		for (l = firstVisibleLevel; l < levels; l++) {
 			levelTiles = tiles[l];
-			for (z = -visibility; z <= 0; z++) {
+			for (worldZ = -visibility; worldZ <= 0; worldZ++) {
 				// TODO: These clamps are slightly breaking, i.e. changes the functionality a bit
-				// this happens because some of the values, when put into method4245,
-				// get added to or subtracted depending on the direction the tile is from the camera.
-				// the clamps ensure none of those error causing mutations can cause a crash but that means
-				// a few cases cannot occur and thus rendering behavior is a little different.
-				local415 = MathUtils.clamp(1, 102, cameraTileX + z);
-				local183 = MathUtils.clamp(1, 102, cameraTileX - z);
-				if (local415 >= LightingManager.minimumVisibleX || local183 < LightingManager.maximumVisibleX) {
-					for (local428 = -visibility; local428 <= 0; local428++) {
-						local434 = MathUtils.clamp(1, 102, cameraTileZ + local428);
-						local438 = MathUtils.clamp(1, 102, cameraTileZ - local428);
-						if (local415 >= LightingManager.minimumVisibleX) {
-							if (local434 >= LightingManager.minimumVisibleZ) {
-								tileToRender = levelTiles[local415][local434];
-								if (tileToRender != null && tileToRender.aBoolean45) {
-									method4245(tileToRender, true);
+				// when the camera is outside the bounds of the map, the very first tile on the
+				// negative edge X and negative edge Z don't get rendered because minimumVisibleX/Z
+				// are 1 when they should ideally be 0 but the game crashes. needs fixing.
+				positiveXEdge = cameraTileX + worldZ;
+				negativeXEdge = cameraTileX - worldZ;
+				if (positiveXEdge >= LightingManager.minimumVisibleX || negativeXEdge < LightingManager.maximumVisibleX) {
+					for (worldX = -visibility; worldX <= 0; worldX++) {
+						positiveZEdge = cameraTileZ + worldX;
+						negativeZEdge = cameraTileZ - worldX;
+						if (positiveXEdge >= LightingManager.minimumVisibleX) {
+							if (positiveXEdge < LightingManager.maximumVisibleX) {
+								if (positiveZEdge >= LightingManager.minimumVisibleZ) {
+									if (positiveZEdge < LightingManager.maximumVisibleZ) {
+										tileToRender = levelTiles[positiveXEdge][positiveZEdge];
+										if (tileToRender != null && tileToRender.aBoolean45) {
+											addTileToRenderStack(tileToRender, true);
+										}
+									}
 								}
-							}
-							if (local438 < LightingManager.maximumVisibleZ) {
-								tileToRender = levelTiles[local415][local438];
-								if (tileToRender != null && tileToRender.aBoolean45) {
-									method4245(tileToRender, true);
+								if (negativeZEdge < LightingManager.maximumVisibleZ) {
+									if (negativeZEdge >= LightingManager.minimumVisibleZ) {
+										tileToRender = levelTiles[positiveXEdge][negativeZEdge];
+										if (tileToRender != null && tileToRender.aBoolean45) {
+											addTileToRenderStack(tileToRender, true);
+										}
+									}
 								}
 							}
 						}
-						if (local183 < LightingManager.maximumVisibleX) {
-							if (local434 >= LightingManager.minimumVisibleZ) {
-								tileToRender = levelTiles[local183][local434];
-								if (tileToRender != null && tileToRender.aBoolean45) {
-									method4245(tileToRender, true);
+						if (negativeXEdge < LightingManager.maximumVisibleX) {
+							if (negativeXEdge >= LightingManager.minimumVisibleX) {
+								if (positiveZEdge >= LightingManager.minimumVisibleZ) {
+									if (positiveZEdge < LightingManager.maximumVisibleZ) {
+										tileToRender = levelTiles[negativeXEdge][positiveZEdge];
+										if (tileToRender != null && tileToRender.aBoolean45) {
+											addTileToRenderStack(tileToRender, true);
+										}
+									}
 								}
-							}
-							if (local438 < LightingManager.maximumVisibleZ) {
-								tileToRender = levelTiles[local183][local438];
-								if (tileToRender != null && tileToRender.aBoolean45) {
-									method4245(tileToRender, true);
+								if (negativeZEdge < LightingManager.maximumVisibleZ) {
+									if (negativeZEdge >= LightingManager.minimumVisibleZ) {
+										tileToRender = levelTiles[negativeXEdge][negativeZEdge];
+										if (tileToRender != null && tileToRender.aBoolean45) {
+											addTileToRenderStack(tileToRender, true);
+										}
+									}
 								}
 							}
 						}
 						if (anInt1142 == 0) {
-							if (!local240) {
+							if (!heights) {
 								MiniMenu.aBoolean187 = false;
 							}
 							return;
@@ -3137,43 +3149,55 @@ public class SceneGraph {
 		}
 		for (l = firstVisibleLevel; l < levels; l++) {
 			levelTiles = tiles[l];
-			for (z = -visibility; z <= 0; z++) {
-				local415 = MathUtils.clamp(1, 102, cameraTileX + z);
-				local183 = MathUtils.clamp(1, 102, cameraTileX - z);
-				if (local415 >= LightingManager.minimumVisibleX || local183 < LightingManager.maximumVisibleX) {
-					for (local428 = -visibility; local428 <= 0; local428++) {
-						local434 = MathUtils.clamp(1, 102, cameraTileZ + local428);
-						local438 = MathUtils.clamp(1, 102, cameraTileZ - local428);
-						if (local415 >= LightingManager.minimumVisibleX) {
-							if (local434 >= LightingManager.minimumVisibleZ) {
-								tileToRender = levelTiles[local415][local434];
-								if (tileToRender != null && tileToRender.aBoolean45) {
-									method4245(tileToRender, false);
+			for (worldZ = -visibility; worldZ <= 0; worldZ++) {
+				positiveXEdge = cameraTileX + worldZ;
+				negativeXEdge = cameraTileX - worldZ;
+				if (positiveXEdge >= LightingManager.minimumVisibleX || negativeXEdge < LightingManager.maximumVisibleX) {
+					for (worldX = -visibility; worldX <= 0; worldX++) {
+						positiveZEdge = cameraTileZ + worldX;
+						negativeZEdge = cameraTileZ - worldX;
+						if (positiveXEdge >= LightingManager.minimumVisibleX) {
+							if (positiveXEdge < LightingManager.maximumVisibleX) {
+								if (positiveZEdge >= LightingManager.minimumVisibleZ) {
+									if (positiveZEdge < LightingManager.maximumVisibleZ) {
+										tileToRender = levelTiles[positiveXEdge][positiveZEdge];
+										if (tileToRender != null && tileToRender.aBoolean45) {
+											addTileToRenderStack(tileToRender, false);
+										}
+									}
 								}
-							}
-							if (local438 < LightingManager.maximumVisibleZ) {
-								tileToRender = levelTiles[local415][local438];
-								if (tileToRender != null && tileToRender.aBoolean45) {
-									method4245(tileToRender, false);
+								if (negativeZEdge < LightingManager.maximumVisibleZ) {
+									if (negativeZEdge >= LightingManager.minimumVisibleZ) {
+										tileToRender = levelTiles[positiveXEdge][negativeZEdge];
+										if (tileToRender != null && tileToRender.aBoolean45) {
+											addTileToRenderStack(tileToRender, false);
+										}
+									}
 								}
 							}
 						}
-						if (local183 < LightingManager.maximumVisibleX) {
-							if (local434 >= LightingManager.minimumVisibleZ) {
-								tileToRender = levelTiles[local183][local434];
-								if (tileToRender != null && tileToRender.aBoolean45) {
-									method4245(tileToRender, false);
+						if (negativeXEdge < LightingManager.maximumVisibleX) {
+							if (negativeXEdge >= LightingManager.minimumVisibleX) {
+								if (positiveZEdge >= LightingManager.minimumVisibleZ) {
+									if (positiveZEdge < LightingManager.maximumVisibleZ) {
+										tileToRender = levelTiles[negativeXEdge][positiveZEdge];
+										if (tileToRender != null && tileToRender.aBoolean45) {
+											addTileToRenderStack(tileToRender, false);
+										}
+									}
 								}
-							}
-							if (local438 < LightingManager.maximumVisibleZ) {
-								tileToRender = levelTiles[local183][local438];
-								if (tileToRender != null && tileToRender.aBoolean45) {
-									method4245(tileToRender, false);
+								if (negativeZEdge < LightingManager.maximumVisibleZ) {
+									if (negativeZEdge >= LightingManager.minimumVisibleZ) {
+										tileToRender = levelTiles[negativeXEdge][negativeZEdge];
+										if (tileToRender != null && tileToRender.aBoolean45) {
+											addTileToRenderStack(tileToRender, false);
+										}
+									}
 								}
 							}
 						}
 						if (anInt1142 == 0) {
-							if (!local240) {
+							if (!heights) {
 								MiniMenu.aBoolean187 = false;
 							}
 							return;

--- a/client/src/main/java/rt4/SceneGraph.java
+++ b/client/src/main/java/rt4/SceneGraph.java
@@ -628,7 +628,7 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!vf", name = "a", descriptor = "(IIIILclient!th;Lclient!th;IIJ)V")
-	public static void setWall(@OriginalArg(0) int level, @OriginalArg(1) int x, @OriginalArg(2) int z, @OriginalArg(3) int arg3, @OriginalArg(4) Entity primary, @OriginalArg(5) Entity secondary, @OriginalArg(6) int arg6, @OriginalArg(7) int arg7, @OriginalArg(8) long key) {
+	public static void setWall(@OriginalArg(0) int level, @OriginalArg(1) int x, @OriginalArg(2) int z, @OriginalArg(3) int y, @OriginalArg(4) Entity primary, @OriginalArg(5) Entity secondary, @OriginalArg(6) int arg6, @OriginalArg(7) int arg7, @OriginalArg(8) long key) {
 		if (primary == null && secondary == null) {
 			return;
 		}
@@ -636,7 +636,7 @@ public class SceneGraph {
 		wall.key = key;
 		wall.xFine = x * 128 + 64;
 		wall.zFine = z * 128 + 64;
-		wall.anInt3051 = arg3;
+		wall.yFine = y;
 		wall.primary = primary;
 		wall.secondary = secondary;
 		wall.anInt3049 = arg6;
@@ -1282,13 +1282,13 @@ public class SceneGraph {
 			}
 			tiles[level][x][z].plainTile = tile;
 		} else {
-			@Pc(134) ShapedTile local134 = new ShapedTile(arg3, arg4, arg5, x, z, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);
+			@Pc(134) ShapedTile shapedTile = new ShapedTile(arg3, arg4, arg5, x, z, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);
 			for (level0 = level; level0 >= 0; level0--) {
 				if (tiles[level0][x][z] == null) {
 					tiles[level0][x][z] = new Tile(level0, x, z);
 				}
 			}
-			tiles[level][x][z].shapedTile = local134;
+			tiles[level][x][z].shapedTile = shapedTile;
 		}
 	}
 
@@ -1329,7 +1329,7 @@ public class SceneGraph {
 
 	@OriginalMember(owner = "client!ib", name = "a", descriptor = "(IIIIIIIILclient!th;IZJ)Z")
 	public static boolean method2256(@OriginalArg(0) int highestLevel, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5, @OriginalArg(6) int arg6, @OriginalArg(7) int arg7, @OriginalArg(8) Entity arg8, @OriginalArg(9) int arg9, @OriginalArg(10) boolean arg10, @OriginalArg(11) long arg11) {
-		@Pc(6) boolean local6 = tileHeights == underwaterTileHeights;
+		@Pc(6) boolean underwater = tileHeights == underwaterTileHeights;
 		@Pc(8) int local8 = 0;
 		@Pc(17) int x;
 		for (@Pc(10) int local10 = arg1; local10 < arg1 + arg3; local10++) {
@@ -1381,12 +1381,12 @@ public class SceneGraph {
 				highestTile.interiorFlags[highestTile.sceneryLen] = local115;
 				highestTile.allInteriorFlags |= local115;
 				highestTile.sceneryLen++;
-				if (local6 && underWaterColors[x][y] != 0) {
+				if (underwater && underWaterColors[x][y] != 0) {
 					local8 = underWaterColors[x][y];
 				}
 			}
 		}
-		if (local6 && local8 != 0) {
+		if (underwater && local8 != 0) {
 			for (x = arg1; x < arg1 + arg3; x++) {
 				for (y = arg2; y < arg2 + arg4; y++) {
 					if (underWaterColors[x][y] == 0) {
@@ -1749,10 +1749,10 @@ public class SceneGraph {
 												}
 												if (local153.plainTile == null) {
 													if (local153.shapedTile != null) {
-														method2762(local153.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, method187(0, nodeX, nodeZ));
+														renderShapedTile(local153.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, method187(0, nodeX, nodeZ));
 													}
 												} else
-													method2610(local153.plainTile, 0, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, method187(0, nodeX, nodeZ));
+													renderPlainTile(local153.plainTile, 0, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, method187(0, nodeX, nodeZ));
 												var22 = local153.wall;
 												if (var22 != null) {
 													if (GlRenderer.enabled) {
@@ -1762,7 +1762,7 @@ public class SceneGraph {
 															LightingManager.method2388(var22.anInt3049, cameraX, cameraY, cameraZ, plane, nodeX, nodeZ);
 														}
 													}
-													var22.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, var22.xFine - cameraX, var22.anInt3051 - cameraY, var22.zFine - cameraZ, var22.key, level, null);
+													var22.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, var22.xFine - cameraX, var22.yFine - cameraY, var22.zFine - cameraZ, var22.key, level, null);
 												}
 												for (sceneryIndex = 0; sceneryIndex < local153.sceneryLen; sceneryIndex++) {
 													scenery = local153.scenery[sceneryIndex];
@@ -1781,18 +1781,18 @@ public class SceneGraph {
 											if (node.plainTile == null) {
 												if (node.shapedTile != null) {
 													if (method187(plane, nodeX, nodeZ)) {
-														method2762(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, true);
+														renderShapedTile(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, true);
 													} else {
 														var24 = true;
-														method2762(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, false);
+														renderShapedTile(node.shapedTile, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, false);
 													}
 												}
 											} else if (method187(plane, nodeX, nodeZ)) {
-												method2610(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, true);
+												renderPlainTile(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, true);
 											} else {
 												var24 = true;
 												if (node.plainTile.anInt4865 != 12345678 || MiniMenu.aBoolean187 && level <= MiniMenu.anInt3902) {
-													method2610(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, false);
+													renderPlainTile(node.plainTile, plane, pitchSin, pitchCos, yawSin, yawCos, nodeX, nodeZ, false);
 												}
 											}
 											if (var24) {
@@ -1852,13 +1852,13 @@ public class SceneGraph {
 													if (GlRenderer.enabled) {
 														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 													}
-													wall.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, wall.xFine - cameraX, wall.anInt3051 - cameraY, wall.zFine - cameraZ, wall.key, level, null);
+													wall.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, wall.xFine - cameraX, wall.yFine - cameraY, wall.zFine - cameraZ, wall.key, level, null);
 												}
 												if ((wall.anInt3052 & sceneryIndex) != 0 && !method3850(plane, nodeX, nodeZ, wall.anInt3052)) {
 													if (GlRenderer.enabled) {
 														LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 													}
-													wall.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, wall.xFine - cameraX, wall.anInt3051 - cameraY, wall.zFine - cameraZ, wall.key, level, null);
+													wall.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, wall.xFine - cameraX, wall.yFine - cameraY, wall.zFine - cameraZ, wall.key, level, null);
 												}
 											}
 											if (wallDecor != null && !method4611(plane, nodeX, nodeZ, wallDecor.primary.getMinY())) {
@@ -2012,7 +2012,7 @@ public class SceneGraph {
 															LightingManager.method2393(cameraX, cameraY, cameraZ, level, nodeX, nodeZ);
 														}
 													}
-													var22.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, var22.xFine - cameraX, var22.anInt3051 - cameraY, var22.zFine - cameraZ, var22.key, level, null);
+													var22.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, var22.xFine - cameraX, var22.yFine - cameraY, var22.zFine - cameraZ, var22.key, level, null);
 												}
 												node.anInt663 = 0;
 											}
@@ -2220,13 +2220,13 @@ public class SceneGraph {
 						if (GlRenderer.enabled) {
 							LightingManager.method2388(local2275.anInt3052, cameraX, cameraY, cameraZ, plane, nodeX, nodeZ);
 						}
-						local2275.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, local2275.xFine - cameraX, local2275.anInt3051 - cameraY, local2275.zFine - cameraZ, local2275.key, level, null);
+						local2275.secondary.render(0, pitchSin, pitchCos, yawSin, yawCos, local2275.xFine - cameraX, local2275.yFine - cameraY, local2275.zFine - cameraZ, local2275.key, level, null);
 					}
 					if ((local2275.anInt3049 & node.anInt670) != 0 && !method3850(plane, nodeX, nodeZ, local2275.anInt3049)) {
 						if (GlRenderer.enabled) {
 							LightingManager.method2388(local2275.anInt3049, cameraX, cameraY, cameraZ, plane, nodeX, nodeZ);
 						}
-						local2275.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, local2275.xFine - cameraX, local2275.anInt3051 - cameraY, local2275.zFine - cameraZ, local2275.key, level, null);
+						local2275.primary.render(0, pitchSin, pitchCos, yawSin, yawCos, local2275.xFine - cameraX, local2275.yFine - cameraY, local2275.zFine - cameraZ, local2275.key, level, null);
 					}
 				}
 			}
@@ -2265,11 +2265,11 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!wh", name = "a", descriptor = "(IIII)Z")
-	public static boolean method4611(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3) {
-		if (method187(arg0, arg1, arg2)) {
-			@Pc(10) int local10 = arg1 << 7;
-			@Pc(14) int local14 = arg2 << 7;
-			return method4394(local10 + 1, tileHeights[arg0][arg1][arg2] + arg3, local14 + 1) && method4394(local10 + 128 - 1, tileHeights[arg0][arg1 + 1][arg2] + arg3, local14 + 1) && method4394(local10 + 128 - 1, tileHeights[arg0][arg1 + 1][arg2 + 1] + arg3, local14 + 128 - 1) && method4394(local10 + 1, tileHeights[arg0][arg1][arg2 + 1] + arg3, local14 + 128 - 1);
+	public static boolean method4611(@OriginalArg(0) int level, @OriginalArg(1) int x, @OriginalArg(2) int z, @OriginalArg(3) int heightOffset) {
+		if (method187(level, x, z)) {
+			@Pc(10) int xFine = x << 7;
+			@Pc(14) int zFine = z << 7;
+			return method4394(xFine + 1, tileHeights[level][x][z] + heightOffset, zFine + 1) && method4394(xFine + 128 - 1, tileHeights[level][x + 1][z] + heightOffset, zFine + 1) && method4394(xFine + 128 - 1, tileHeights[level][x + 1][z + 1] + heightOffset, zFine + 128 - 1) && method4394(xFine + 1, tileHeights[level][x][z + 1] + heightOffset, zFine + 128 - 1);
 		} else {
 			return false;
 		}
@@ -3009,9 +3009,9 @@ public class SceneGraph {
 							if (x >= local9 && x <= local13 && z >= local17 && z <= local21) {
 								if (tile.wall != null) {
 									@Pc(103) Wall wall = tile.wall;
-									wall.primary.method4545(0, currentLevel, wall.anInt3051, wall.xFine, wall.zFine);
+									wall.primary.method4545(0, currentLevel, wall.yFine, wall.xFine, wall.zFine);
 									if (wall.secondary != null) {
-										wall.secondary.method4545(0, currentLevel, wall.anInt3051, wall.xFine, wall.zFine);
+										wall.secondary.method4545(0, currentLevel, wall.yFine, wall.xFine, wall.zFine);
 									}
 								}
 								if (tile.wallDecor != null) {
@@ -3828,29 +3828,29 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!ge", name = "a", descriptor = "(IIIIIIII)V")
-	public static void method1698(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(6) int arg5, @OriginalArg(7) int arg6) {
-		if (arg1 < 1 || arg4 < 1 || arg1 > 102 || arg4 > 102) {
+	public static void method1698(@OriginalArg(0) int arg0, @OriginalArg(1) int x, @OriginalArg(2) int level, @OriginalArg(3) int arg3, @OriginalArg(4) int z, @OriginalArg(6) int arg5, @OriginalArg(7) int arg6) {
+		if (x < 1 || z < 1 || x > 102 || z > 102) {
 			return;
 		}
 		@Pc(39) int local39;
-		if (!allLevelsAreVisible() && (tileRenderFlags[0][arg1][arg4] & 0x2) == 0) {
-			local39 = arg2;
-			if ((tileRenderFlags[arg2][arg1][arg4] & 0x8) != 0) {
+		if (!allLevelsAreVisible() && (tileRenderFlags[0][x][z] & 0x2) == 0) {
+			local39 = level;
+			if ((tileRenderFlags[level][x][z] & 0x8) != 0) {
 				local39 = 0;
 			}
 			if (local39 != centralPlane) {
 				return;
 			}
 		}
-		local39 = arg2;
-		if (arg2 < 3 && (tileRenderFlags[1][arg1][arg4] & 0x2) == 2) {
-			local39 = arg2 + 1;
+		local39 = level;
+		if (level < 3 && (tileRenderFlags[1][x][z] & 0x2) == 2) {
+			local39 = level + 1;
 		}
-		method1144(arg4, arg1, arg2, arg6, local39, PathFinder.collisionMaps[arg2]);
+		method1144(z, x, level, arg6, local39, PathFinder.collisionMaps[level]);
 		if (arg0 >= 0) {
 			@Pc(92) boolean local92 = Preferences.showGroundDecorations;
 			Preferences.showGroundDecorations = true;
-			addLoc(local39, false, arg2, false, PathFinder.collisionMaps[arg2], arg0, arg5, arg1, arg4, arg3);
+			addLoc(local39, false, level, false, PathFinder.collisionMaps[level], arg0, arg5, x, z, arg3);
 			Preferences.showGroundDecorations = local92;
 		}
 	}
@@ -3876,51 +3876,51 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!ke", name = "a", descriptor = "(Lclient!rh;IIIIIIIZ)V")
-	public static void method2610(@OriginalArg(0) PlainTile arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5, @OriginalArg(6) int arg6, @OriginalArg(7) int arg7, @OriginalArg(8) boolean arg8) {
+	public static void renderPlainTile(@OriginalArg(0) PlainTile tile, @OriginalArg(1) int plane, @OriginalArg(2) int pitchSin, @OriginalArg(3) int pitchCos, @OriginalArg(4) int yawSin, @OriginalArg(5) int yawCos, @OriginalArg(6) int tileX, @OriginalArg(7) int tileZ, @OriginalArg(8) boolean arg8) {
 		@Pc(6) int local6;
-		@Pc(7) int local7 = local6 = (arg6 << 7) - cameraX;
+		@Pc(7) int local7 = local6 = (tileX << 7) - cameraX;
 		@Pc(14) int local14;
-		@Pc(15) int local15 = local14 = (arg7 << 7) - cameraZ;
+		@Pc(15) int local15 = local14 = (tileZ << 7) - cameraZ;
 		@Pc(20) int local20;
 		@Pc(21) int local21 = local20 = local7 + 128;
 		@Pc(26) int local26;
 		@Pc(27) int local27 = local26 = local15 + 128;
-		@Pc(37) int local37 = tileHeights[arg1][arg6][arg7] - cameraY;
-		@Pc(49) int local49 = tileHeights[arg1][arg6 + 1][arg7] - cameraY;
-		@Pc(63) int local63 = tileHeights[arg1][arg6 + 1][arg7 + 1] - cameraY;
-		@Pc(75) int local75 = tileHeights[arg1][arg6][arg7 + 1] - cameraY;
-		@Pc(85) int local85 = local15 * arg4 + local7 * arg5 >> 16;
-		@Pc(95) int local95 = local15 * arg5 - local7 * arg4 >> 16;
+		@Pc(37) int local37 = tileHeights[plane][tileX][tileZ] - cameraY;
+		@Pc(49) int local49 = tileHeights[plane][tileX + 1][tileZ] - cameraY;
+		@Pc(63) int local63 = tileHeights[plane][tileX + 1][tileZ + 1] - cameraY;
+		@Pc(75) int local75 = tileHeights[plane][tileX][tileZ + 1] - cameraY;
+		@Pc(85) int local85 = local15 * yawSin + local7 * yawCos >> 16;
+		@Pc(95) int local95 = local15 * yawCos - local7 * yawSin >> 16;
 		@Pc(97) int local97 = local85;
-		@Pc(107) int local107 = local37 * arg3 - local95 * arg2 >> 16;
-		@Pc(117) int local117 = local37 * arg2 + local95 * arg3 >> 16;
+		@Pc(107) int local107 = local37 * pitchCos - local95 * pitchSin >> 16;
+		@Pc(117) int local117 = local37 * pitchSin + local95 * pitchCos >> 16;
 		@Pc(119) int local119 = local107;
 		if (local117 < 50) {
 			return;
 		}
-		local85 = local14 * arg4 + local21 * arg5 >> 16;
-		@Pc(143) int local143 = local14 * arg5 - local21 * arg4 >> 16;
+		local85 = local14 * yawSin + local21 * yawCos >> 16;
+		@Pc(143) int local143 = local14 * yawCos - local21 * yawSin >> 16;
 		local21 = local85;
-		local85 = local49 * arg3 - local143 * arg2 >> 16;
-		@Pc(165) int local165 = local49 * arg2 + local143 * arg3 >> 16;
+		local85 = local49 * pitchCos - local143 * pitchSin >> 16;
+		@Pc(165) int local165 = local49 * pitchSin + local143 * pitchCos >> 16;
 		local49 = local85;
 		if (local165 < 50) {
 			return;
 		}
-		local85 = local27 * arg4 + local20 * arg5 >> 16;
-		local27 = local27 * arg5 - local20 * arg4 >> 16;
+		local85 = local27 * yawSin + local20 * yawCos >> 16;
+		local27 = local27 * yawCos - local20 * yawSin >> 16;
 		@Pc(193) int local193 = local85;
-		local85 = local63 * arg3 - local27 * arg2 >> 16;
-		local27 = local63 * arg2 + local27 * arg3 >> 16;
+		local85 = local63 * pitchCos - local27 * pitchSin >> 16;
+		local27 = local63 * pitchSin + local27 * pitchCos >> 16;
 		local63 = local85;
 		if (local27 < 50) {
 			return;
 		}
-		local85 = local26 * arg4 + local6 * arg5 >> 16;
-		@Pc(239) int local239 = local26 * arg5 - local6 * arg4 >> 16;
+		local85 = local26 * yawSin + local6 * yawCos >> 16;
+		@Pc(239) int local239 = local26 * yawCos - local6 * yawSin >> 16;
 		@Pc(241) int local241 = local85;
-		local85 = local75 * arg3 - local239 * arg2 >> 16;
-		@Pc(261) int local261 = local75 * arg2 + local239 * arg3 >> 16;
+		local85 = local75 * pitchCos - local239 * pitchSin >> 16;
+		@Pc(261) int local261 = local75 * pitchSin + local239 * pitchCos >> 16;
 		if (local261 < 50) {
 			return;
 		}
@@ -3936,22 +3936,22 @@ public class SceneGraph {
 		@Pc(475) int local475;
 		if ((local307 - local323) * (local299 - local331) - (local315 - local331) * (local291 - local323) > 0) {
 			if (MiniMenu.aBoolean187 && method583(MiniMenu.anInt2388 + Rasteriser.centerX, MiniMenu.anInt3259 + Rasteriser.centerY, local315, local331, local299, local307, local323, local291)) {
-				MiniMenu.anInt1742 = arg6;
-				MiniMenu.anInt2954 = arg7;
+				MiniMenu.anInt1742 = tileX;
+				MiniMenu.anInt2954 = tileZ;
 			}
 			if (!GlRenderer.enabled && !arg8) {
 				Rasteriser.testX = local307 < 0 || local323 < 0 || local291 < 0 || local307 > Rasteriser.width || local323 > Rasteriser.width || local291 > Rasteriser.width;
-				if (arg0.anInt4869 == -1) {
-					if (arg0.anInt4865 != 12345678) {
-						Rasteriser.fillGouraudTriangle(local315, local331, local299, local307, local323, local291, arg0.anInt4865, arg0.anInt4864, arg0.anInt4867);
+				if (tile.tileTexture == -1) {
+					if (tile.anInt4865 != 12345678) {
+						Rasteriser.fillGouraudTriangle(local315, local331, local299, local307, local323, local291, tile.anInt4865, tile.anInt4864, tile.anInt4867);
 					}
 				} else if (!Preferences.manyGroundTextures) {
-					local475 = Rasteriser.textureProvider.getAverageColor(arg0.anInt4869);
-					Rasteriser.fillGouraudTriangle(local315, local331, local299, local307, local323, local291, ColorUtils.multiplyLightness3(local475, arg0.anInt4865), ColorUtils.multiplyLightness3(local475, arg0.anInt4864), ColorUtils.multiplyLightness3(local475, arg0.anInt4867));
-				} else if (arg0.aBoolean241) {
-					Rasteriser.fillTexturedTriangle(local315, local331, local299, local307, local323, local291, arg0.anInt4865, arg0.anInt4864, arg0.anInt4867, local97, local21, local241, local119, local49, local85, local117, local165, local261, arg0.anInt4869);
+					local475 = Rasteriser.textureProvider.getAverageColor(tile.tileTexture);
+					Rasteriser.fillGouraudTriangle(local315, local331, local299, local307, local323, local291, ColorUtils.multiplyLightness3(local475, tile.anInt4865), ColorUtils.multiplyLightness3(local475, tile.anInt4864), ColorUtils.multiplyLightness3(local475, tile.anInt4867));
+				} else if (tile.aBoolean241) {
+					Rasteriser.fillTexturedTriangle(local315, local331, local299, local307, local323, local291, tile.anInt4865, tile.anInt4864, tile.anInt4867, local97, local21, local241, local119, local49, local85, local117, local165, local261, tile.tileTexture);
 				} else {
-					Rasteriser.fillTexturedTriangle(local315, local331, local299, local307, local323, local291, arg0.anInt4865, arg0.anInt4864, arg0.anInt4867, local193, local241, local21, local63, local85, local49, local27, local261, local165, arg0.anInt4869);
+					Rasteriser.fillTexturedTriangle(local315, local331, local299, local307, local323, local291, tile.anInt4865, tile.anInt4864, tile.anInt4867, local193, local241, local21, local63, local85, local49, local27, local261, local165, tile.tileTexture);
 				}
 			}
 		}
@@ -3959,22 +3959,22 @@ public class SceneGraph {
 			return;
 		}
 		if (MiniMenu.aBoolean187 && method583(MiniMenu.anInt2388 + Rasteriser.centerX, MiniMenu.anInt3259 + Rasteriser.centerY, local283, local299, local331, local275, local291, local323)) {
-			MiniMenu.anInt1742 = arg6;
-			MiniMenu.anInt2954 = arg7;
+			MiniMenu.anInt1742 = tileX;
+			MiniMenu.anInt2954 = tileZ;
 		}
 		if (GlRenderer.enabled || arg8) {
 			return;
 		}
 		Rasteriser.testX = local275 < 0 || local291 < 0 || local323 < 0 || local275 > Rasteriser.width || local291 > Rasteriser.width || local323 > Rasteriser.width;
-		if (arg0.anInt4869 == -1) {
-			if (arg0.anInt4872 != 12345678) {
-				Rasteriser.fillGouraudTriangle(local283, local299, local331, local275, local291, local323, arg0.anInt4872, arg0.anInt4867, arg0.anInt4864);
+		if (tile.tileTexture == -1) {
+			if (tile.anInt4872 != 12345678) {
+				Rasteriser.fillGouraudTriangle(local283, local299, local331, local275, local291, local323, tile.anInt4872, tile.anInt4867, tile.anInt4864);
 			}
 		} else if (Preferences.manyGroundTextures) {
-			Rasteriser.fillTexturedTriangle(local283, local299, local331, local275, local291, local323, arg0.anInt4872, arg0.anInt4867, arg0.anInt4864, local97, local21, local241, local119, local49, local85, local117, local165, local261, arg0.anInt4869);
+			Rasteriser.fillTexturedTriangle(local283, local299, local331, local275, local291, local323, tile.anInt4872, tile.anInt4867, tile.anInt4864, local97, local21, local241, local119, local49, local85, local117, local165, local261, tile.tileTexture);
 		} else {
-			local475 = Rasteriser.textureProvider.getAverageColor(arg0.anInt4869);
-			Rasteriser.fillGouraudTriangle(local283, local299, local331, local275, local291, local323, ColorUtils.multiplyLightness3(local475, arg0.anInt4872), ColorUtils.multiplyLightness3(local475, arg0.anInt4867), ColorUtils.multiplyLightness3(local475, arg0.anInt4864));
+			local475 = Rasteriser.textureProvider.getAverageColor(tile.tileTexture);
+			Rasteriser.fillGouraudTriangle(local283, local299, local331, local275, local291, local323, ColorUtils.multiplyLightness3(local475, tile.anInt4872), ColorUtils.multiplyLightness3(local475, tile.anInt4867), ColorUtils.multiplyLightness3(local475, tile.anInt4864));
 		}
 	}
 
@@ -4249,25 +4249,25 @@ public class SceneGraph {
 	}
 
 	@OriginalMember(owner = "client!lh", name = "a", descriptor = "(Lclient!fg;IIIIIIZ)V")
-	public static void method2762(@OriginalArg(0) ShapedTile arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5, @OriginalArg(6) int arg6, @OriginalArg(7) boolean arg7) {
-		@Pc(3) int local3 = arg0.anIntArray168.length;
+	public static void renderShapedTile(@OriginalArg(0) ShapedTile tile, @OriginalArg(1) int pitchSin, @OriginalArg(2) int pitchCos, @OriginalArg(3) int yawSin, @OriginalArg(4) int yawCos, @OriginalArg(5) int x, @OriginalArg(6) int y, @OriginalArg(7) boolean arg7) {
+		@Pc(3) int local3 = tile.anIntArray168.length;
 		@Pc(5) int local5;
 		@Pc(15) int local15;
 		@Pc(22) int local22;
 		@Pc(29) int local29;
 		@Pc(39) int local39;
 		for (local5 = 0; local5 < local3; local5++) {
-			local15 = arg0.anIntArray168[local5] - cameraX;
-			local22 = arg0.anIntArray160[local5] - cameraY;
-			local29 = arg0.anIntArray163[local5] - cameraZ;
-			local39 = local29 * arg3 + local15 * arg4 >> 16;
-			@Pc(49) int local49 = local29 * arg4 - local15 * arg3 >> 16;
-			@Pc(61) int local61 = local22 * arg2 - local49 * arg1 >> 16;
-			@Pc(71) int local71 = local22 * arg1 + local49 * arg2 >> 16;
+			local15 = tile.anIntArray168[local5] - cameraX;
+			local22 = tile.anIntArray160[local5] - cameraY;
+			local29 = tile.anIntArray163[local5] - cameraZ;
+			local39 = local29 * yawSin + local15 * yawCos >> 16;
+			@Pc(49) int local49 = local29 * yawCos - local15 * yawSin >> 16;
+			@Pc(61) int local61 = local22 * pitchCos - local49 * pitchSin >> 16;
+			@Pc(71) int local71 = local22 * pitchSin + local49 * pitchCos >> 16;
 			if (local71 < 50) {
 				return;
 			}
-			if (arg0.anIntArray161 != null) {
+			if (tile.anIntArray161 != null) {
 				anIntArray159[local5] = local39;
 				anIntArray170[local5] = local61;
 				anIntArray169[local5] = local71;
@@ -4276,11 +4276,11 @@ public class SceneGraph {
 			anIntArray164[local5] = Rasteriser.centerY + (local61 << 9) / local71;
 		}
 		Rasteriser.alpha = 0;
-		local3 = arg0.anIntArray166.length;
+		local3 = tile.anIntArray166.length;
 		for (local5 = 0; local5 < local3; local5++) {
-			local15 = arg0.anIntArray166[local5];
-			local22 = arg0.anIntArray162[local5];
-			local29 = arg0.anIntArray158[local5];
+			local15 = tile.anIntArray166[local5];
+			local22 = tile.anIntArray162[local5];
+			local29 = tile.anIntArray158[local5];
 			local39 = anIntArray165[local15];
 			@Pc(148) int local148 = anIntArray165[local22];
 			@Pc(152) int local152 = anIntArray165[local29];
@@ -4289,22 +4289,22 @@ public class SceneGraph {
 			@Pc(164) int local164 = anIntArray164[local29];
 			if ((local39 - local148) * (local164 - local160) - (local156 - local160) * (local152 - local148) > 0) {
 				if (MiniMenu.aBoolean187 && method583(MiniMenu.anInt2388 + Rasteriser.centerX, MiniMenu.anInt3259 + Rasteriser.centerY, local156, local160, local164, local39, local148, local152)) {
-					MiniMenu.anInt1742 = arg5;
-					MiniMenu.anInt2954 = arg6;
+					MiniMenu.anInt1742 = x;
+					MiniMenu.anInt2954 = y;
 				}
 				if (!GlRenderer.enabled && !arg7) {
 					Rasteriser.testX = local39 < 0 || local148 < 0 || local152 < 0 || local39 > Rasteriser.width || local148 > Rasteriser.width || local152 > Rasteriser.width;
-					if (arg0.anIntArray161 == null || arg0.anIntArray161[local5] == -1) {
-						if (arg0.anIntArray167[local5] != 12345678) {
-							Rasteriser.fillGouraudTriangle(local156, local160, local164, local39, local148, local152, arg0.anIntArray167[local5], arg0.anIntArray172[local5], arg0.anIntArray171[local5]);
+					if (tile.anIntArray161 == null || tile.anIntArray161[local5] == -1) {
+						if (tile.anIntArray167[local5] != 12345678) {
+							Rasteriser.fillGouraudTriangle(local156, local160, local164, local39, local148, local152, tile.anIntArray167[local5], tile.anIntArray172[local5], tile.anIntArray171[local5]);
 						}
 					} else if (!Preferences.manyGroundTextures) {
-						@Pc(373) int local373 = Rasteriser.textureProvider.getAverageColor(arg0.anIntArray161[local5]);
-						Rasteriser.fillGouraudTriangle(local156, local160, local164, local39, local148, local152, ColorUtils.multiplyLightness3(local373, arg0.anIntArray167[local5]), ColorUtils.multiplyLightness3(local373, arg0.anIntArray172[local5]), ColorUtils.multiplyLightness3(local373, arg0.anIntArray171[local5]));
-					} else if (arg0.aBoolean113) {
-						Rasteriser.fillTexturedTriangle(local156, local160, local164, local39, local148, local152, arg0.anIntArray167[local5], arg0.anIntArray172[local5], arg0.anIntArray171[local5], anIntArray159[0], anIntArray159[1], anIntArray159[3], anIntArray170[0], anIntArray170[1], anIntArray170[3], anIntArray169[0], anIntArray169[1], anIntArray169[3], arg0.anIntArray161[local5]);
+						@Pc(373) int local373 = Rasteriser.textureProvider.getAverageColor(tile.anIntArray161[local5]);
+						Rasteriser.fillGouraudTriangle(local156, local160, local164, local39, local148, local152, ColorUtils.multiplyLightness3(local373, tile.anIntArray167[local5]), ColorUtils.multiplyLightness3(local373, tile.anIntArray172[local5]), ColorUtils.multiplyLightness3(local373, tile.anIntArray171[local5]));
+					} else if (tile.aBoolean113) {
+						Rasteriser.fillTexturedTriangle(local156, local160, local164, local39, local148, local152, tile.anIntArray167[local5], tile.anIntArray172[local5], tile.anIntArray171[local5], anIntArray159[0], anIntArray159[1], anIntArray159[3], anIntArray170[0], anIntArray170[1], anIntArray170[3], anIntArray169[0], anIntArray169[1], anIntArray169[3], tile.anIntArray161[local5]);
 					} else {
-						Rasteriser.fillTexturedTriangle(local156, local160, local164, local39, local148, local152, arg0.anIntArray167[local5], arg0.anIntArray172[local5], arg0.anIntArray171[local5], anIntArray159[local15], anIntArray159[local22], anIntArray159[local29], anIntArray170[local15], anIntArray170[local22], anIntArray170[local29], anIntArray169[local15], anIntArray169[local22], anIntArray169[local29], arg0.anIntArray161[local5]);
+						Rasteriser.fillTexturedTriangle(local156, local160, local164, local39, local148, local152, tile.anIntArray167[local5], tile.anIntArray172[local5], tile.anIntArray171[local5], anIntArray159[local15], anIntArray159[local22], anIntArray159[local29], anIntArray170[local15], anIntArray170[local22], anIntArray170[local29], anIntArray169[local15], anIntArray169[local22], anIntArray169[local29], tile.anIntArray161[local5]);
 					}
 				}
 			}

--- a/client/src/main/java/rt4/SceneGraph.java
+++ b/client/src/main/java/rt4/SceneGraph.java
@@ -3086,12 +3086,17 @@ public class SceneGraph {
 		for (l = firstVisibleLevel; l < levels; l++) {
 			levelTiles = tiles[l];
 			for (z = -visibility; z <= 0; z++) {
-				local415 = cameraTileX + z;
-				local183 = cameraTileX - z;
+				// TODO: These clamps are slightly breaking, i.e. changes the functionality a bit
+				// this happens because some of the values, when put into method4245,
+				// get added to or subtracted depending on the direction the tile is from the camera.
+				// the clamps ensure none of those error causing mutations can cause a crash but that means
+				// a few cases cannot occur and thus rendering behavior is a little different.
+				local415 = MathUtils.clamp(1, 102, cameraTileX + z);
+				local183 = MathUtils.clamp(1, 102, cameraTileX - z);
 				if (local415 >= LightingManager.minimumVisibleX || local183 < LightingManager.maximumVisibleX) {
 					for (local428 = -visibility; local428 <= 0; local428++) {
-						local434 = cameraTileZ + local428;
-						local438 = cameraTileZ - local428;
+						local434 = MathUtils.clamp(1, 102, cameraTileZ + local428);
+						local438 = MathUtils.clamp(1, 102, cameraTileZ - local428);
 						if (local415 >= LightingManager.minimumVisibleX) {
 							if (local434 >= LightingManager.minimumVisibleZ) {
 								tileToRender = levelTiles[local415][local434];
@@ -3133,12 +3138,12 @@ public class SceneGraph {
 		for (l = firstVisibleLevel; l < levels; l++) {
 			levelTiles = tiles[l];
 			for (z = -visibility; z <= 0; z++) {
-				local415 = cameraTileX + z;
-				local183 = cameraTileX - z;
+				local415 = MathUtils.clamp(1, 102, cameraTileX + z);
+				local183 = MathUtils.clamp(1, 102, cameraTileX - z);
 				if (local415 >= LightingManager.minimumVisibleX || local183 < LightingManager.maximumVisibleX) {
 					for (local428 = -visibility; local428 <= 0; local428++) {
-						local434 = cameraTileZ + local428;
-						local438 = cameraTileZ - local428;
+						local434 = MathUtils.clamp(1, 102, cameraTileZ + local428);
+						local438 = MathUtils.clamp(1, 102, cameraTileZ - local428);
 						if (local415 >= LightingManager.minimumVisibleX) {
 							if (local434 >= LightingManager.minimumVisibleZ) {
 								tileToRender = levelTiles[local415][local434];

--- a/client/src/main/java/rt4/SceneGraph.java
+++ b/client/src/main/java/rt4/SceneGraph.java
@@ -216,6 +216,11 @@ public class SceneGraph {
 		if (level < 3 && (tileRenderFlags[1][x][z] & 0x2) == 2) {
 			virtualLevel = level + 1;
 		}
+
+		if (virtualLevel >= tileHeights.length) {
+			return 0;
+		}
+
 		@Pc(91) int heightZ0 = xFine2 * tileHeights[virtualLevel][x + 1][z + 1] + tileHeights[virtualLevel][x][z + 1] * (128 - xFine2) >> 7;
 		@Pc(118) int heightZ1 = xFine2 * tileHeights[virtualLevel][x + 1][z] + (128 - xFine2) * tileHeights[virtualLevel][x][z] >> 7;
 		return zFine2 * heightZ0 + (128 - zFine2) * heightZ1 >> 7;

--- a/client/src/main/java/rt4/SceneGraph.java
+++ b/client/src/main/java/rt4/SceneGraph.java
@@ -2909,6 +2909,10 @@ public class SceneGraph {
 		cameraTileX = renderX / 128;
 		cameraTileZ = renderZ / 128;
 		LightingManager.minimumVisibleX = cameraTileX - visibility;
+		// TODO: Setting these to 1 instead of 0 is slightly breaking, i.e. changes the functionality a bit
+		// when the camera is outside the bounds of the map, the very first tile on the
+		// negative edge X and negative edge Z don't get rendered because minimumVisibleX/Z
+		// are 1 when they should ideally be 0 but the game crashes. needs fixing.
 		if (LightingManager.minimumVisibleX <= 0) {
 			LightingManager.minimumVisibleX = 1;
 		}
@@ -3092,10 +3096,6 @@ public class SceneGraph {
 		for (l = firstVisibleLevel; l < levels; l++) {
 			levelTiles = tiles[l];
 			for (worldZ = -visibility; worldZ <= 0; worldZ++) {
-				// TODO: These clamps are slightly breaking, i.e. changes the functionality a bit
-				// when the camera is outside the bounds of the map, the very first tile on the
-				// negative edge X and negative edge Z don't get rendered because minimumVisibleX/Z
-				// are 1 when they should ideally be 0 but the game crashes. needs fixing.
 				positiveXEdge = cameraTileX + worldZ;
 				negativeXEdge = cameraTileX - worldZ;
 				if (positiveXEdge >= LightingManager.minimumVisibleX || negativeXEdge < LightingManager.maximumVisibleX) {

--- a/client/src/main/java/rt4/ScriptRunner.java
+++ b/client/src/main/java/rt4/ScriptRunner.java
@@ -171,7 +171,7 @@ public final class ScriptRunner {
 					local115 = height * 512 * local51 / (local86 * 334);
 					local122 = (width - local115) / 2;
 					if (dontClip) {
-						GlRaster.method1177();
+						GlRaster.setFullClip();
 						GlRaster.fillRect(x, y, local122, height, 0);
 						GlRaster.fillRect(width + x - local122, y, local122, height, 0);
 					}
@@ -186,7 +186,7 @@ public final class ScriptRunner {
 					local115 = local86 * width * 334 / (local51 * 512);
 					local122 = (height - local115) / 2;
 					if (dontClip) {
-						GlRaster.method1177();
+						GlRaster.setFullClip();
 						GlRaster.fillRect(x, y, width, local122, 0);
 						GlRaster.fillRect(x, y + height - local122, width, local122, 0);
 					}
@@ -496,7 +496,7 @@ public final class ScriptRunner {
 						local639 = local508.width * entity.hitpointsBar / 255;
 						local642 = local508.height;
 						if (GlRenderer.enabled) {
-							GlRaster.method1183(local161, local359, local161 + local639, local359 + local642);
+							GlRaster.shrinkClip(local161, local359, local161 + local639, local359 + local642);
 						} else {
 							SoftwareRaster.method2498(local161, local359, local161 + local639, local642 + local359);
 						}
@@ -618,7 +618,7 @@ public final class ScriptRunner {
 				if (OverheadChat.effects[local5] == 4) {
 					local642 = (150 - OverheadChat.loops[local5]) * (Fonts.b12Full.getStringWidth(local962) + 100) / 150;
 					if (GlRenderer.enabled) {
-						GlRaster.method1183(anInt1951 + arg2 - 50, arg0, anInt1951 + arg2 + 50, arg4 + arg0);
+						GlRaster.shrinkClip(anInt1951 + arg2 - 50, arg0, anInt1951 + arg2 + 50, arg4 + arg0);
 					} else {
 						SoftwareRaster.method2498(arg2 + anInt1951 - 50, arg0, anInt1951 + arg2 + 50, arg4 + arg0);
 					}
@@ -633,7 +633,7 @@ public final class ScriptRunner {
 					@Pc(1372) int local1372 = 0;
 					local642 = 150 - OverheadChat.loops[local5];
 					if (GlRenderer.enabled) {
-						GlRaster.method1183(arg2, anInt548 + arg0 - Fonts.b12Full.lineHeight - 1, arg1 + arg2, arg0 + anInt548 + 5);
+						GlRaster.shrinkClip(arg2, anInt548 + arg0 - Fonts.b12Full.lineHeight - 1, arg1 + arg2, arg0 + anInt548 + 5);
 					} else {
 						SoftwareRaster.method2498(arg2, anInt548 + arg0 - Fonts.b12Full.lineHeight - 1, arg2 + arg1, anInt548 + arg0 + 5);
 					}

--- a/client/src/main/java/rt4/ScriptRunner.java
+++ b/client/src/main/java/rt4/ScriptRunner.java
@@ -88,13 +88,13 @@ public final class ScriptRunner {
 	@OriginalMember(owner = "client!ac", name = "k", descriptor = "S")
 	public static short aShort1 = 32767;
 	@OriginalMember(owner = "client!nc", name = "n", descriptor = "I")
-	public static int anInt4055 = 0;
+	public static int componentWidth = 0;
 	@OriginalMember(owner = "client!tm", name = "i", descriptor = "I")
-	public static int anInt5377 = 0;
+	public static int componentHeight = 0;
 	@OriginalMember(owner = "client!bn", name = "eb", descriptor = "I")
-	public static int anInt773 = 0;
+	public static int componentY = 0;
 	@OriginalMember(owner = "client!ah", name = "n", descriptor = "I")
-	public static int anInt983 = 0;
+	public static int componentX = 0;
 	@OriginalMember(owner = "client!sc", name = "p", descriptor = "I")
 	public static int anInt5029 = 0;
 	@OriginalMember(owner = "client!kd", name = "yb", descriptor = "S")
@@ -110,7 +110,7 @@ public final class ScriptRunner {
 	@OriginalMember(owner = "client!k", name = "m", descriptor = "Z")
 	public static boolean neverRemoveRoofs = false;
 	@OriginalMember(owner = "client!vk", name = "f", descriptor = "[[[B")
-	public static byte[][][] aByteArrayArrayArray15;
+	public static byte[][][] removeRoofTiles;
 	@OriginalMember(owner = "client!vg", name = "b", descriptor = "S")
 	public static short aShort30 = 256;
 	@OriginalMember(owner = "client!vg", name = "c", descriptor = "Z")
@@ -139,15 +139,15 @@ public final class ScriptRunner {
 	public static int anInt3751;
 
 	@OriginalMember(owner = "client!ja", name = "a", descriptor = "(IIIIIZ)V")
-	public static void method2314(@OriginalArg(0) int arg0, @OriginalArg(2) int arg1, @OriginalArg(3) int arg2, @OriginalArg(4) int arg3, @OriginalArg(5) boolean arg4) {
-		if (arg0 < 1) {
-			arg0 = 1;
+	public static void fillRect(@OriginalArg(0) int width, @OriginalArg(2) int y, @OriginalArg(3) int height, @OriginalArg(4) int x, @OriginalArg(5) boolean dontClip) {
+		if (width < 1) {
+			width = 1;
 		}
-		if (arg2 < 1) {
-			arg2 = 1;
+		if (height < 1) {
+			height = 1;
 		}
 		if (GlRenderer.enabled) {
-			@Pc(25) int local25 = arg2 - 334;
+			@Pc(25) int local25 = height - 334;
 			if (local25 < 0) {
 				local25 = 0;
 			} else if (local25 > 100) {
@@ -159,85 +159,85 @@ public final class ScriptRunner {
 			} else if (aShort1 < local51) {
 				local51 = aShort1;
 			}
-			@Pc(73) int local73 = local51 * arg2 * 512 / (arg0 * 334);
+			@Pc(73) int local73 = local51 * height * 512 / (width * 334);
 			@Pc(115) int local115;
 			@Pc(122) int local122;
 			@Pc(86) short local86;
 			if (local73 < aShort12) {
 				local86 = aShort12;
-				local51 = arg0 * 334 * local86 / (arg2 * 512);
+				local51 = width * 334 * local86 / (height * 512);
 				if (aShort1 < local51) {
 					local51 = aShort1;
-					local115 = arg2 * 512 * local51 / (local86 * 334);
-					local122 = (arg0 - local115) / 2;
-					if (arg4) {
+					local115 = height * 512 * local51 / (local86 * 334);
+					local122 = (width - local115) / 2;
+					if (dontClip) {
 						GlRaster.method1177();
-						GlRaster.fillRect(arg3, arg1, local122, arg2, 0);
-						GlRaster.fillRect(arg0 + arg3 - local122, arg1, local122, arg2, 0);
+						GlRaster.fillRect(x, y, local122, height, 0);
+						GlRaster.fillRect(width + x - local122, y, local122, height, 0);
 					}
-					arg3 += local122;
-					arg0 -= local122 * 2;
+					x += local122;
+					width -= local122 * 2;
 				}
 			} else if (aShort21 < local73) {
 				local86 = aShort21;
-				local51 = local86 * arg0 * 334 / (arg2 * 512);
+				local51 = local86 * width * 334 / (height * 512);
 				if (aShort22 > local51) {
 					local51 = aShort22;
-					local115 = local86 * arg0 * 334 / (local51 * 512);
-					local122 = (arg2 - local115) / 2;
-					if (arg4) {
+					local115 = local86 * width * 334 / (local51 * 512);
+					local122 = (height - local115) / 2;
+					if (dontClip) {
 						GlRaster.method1177();
-						GlRaster.fillRect(arg3, arg1, arg0, local122, 0);
-						GlRaster.fillRect(arg3, arg1 + arg2 - local122, arg0, local122, 0);
+						GlRaster.fillRect(x, y, width, local122, 0);
+						GlRaster.fillRect(x, y + height - local122, width, local122, 0);
 					}
-					arg2 -= local122 * 2;
-					arg1 += local122;
+					height -= local122 * 2;
+					y += local122;
 				}
 			}
-			anInt5029 = local51 * arg2 / 334;
+			anInt5029 = local51 * height / 334;
 		}
-		anInt4055 = (short) arg0;
-		anInt5377 = (short) arg2;
-		anInt773 = arg1;
-		anInt983 = arg3;
+		componentWidth = (short) width;
+		componentHeight = (short) height;
+		componentY = y;
+		componentX = x;
 	}
 
 	@OriginalMember(owner = "client!ui", name = "a", descriptor = "(IIZIII)V")
-	public static void method4326(@OriginalArg(1) int arg0, @OriginalArg(2) boolean arg1, @OriginalArg(3) int arg2, @OriginalArg(4) int arg3, @OriginalArg(5) int arg4) {
+	public static void renderComponent(@OriginalArg(1) int height, @OriginalArg(2) boolean renderOnTop, @OriginalArg(3) int x, @OriginalArg(4) int width, @OriginalArg(5) int y) {
 		anInt3325++;
 		method3711();
-		if (!arg1) {
+		if (!renderOnTop) {
 			method964(true);
 			method3240(true);
 			method964(false);
 		}
 		method3240(false);
-		if (!arg1) {
+		if (!renderOnTop) {
 			updateSceneProjectiles();
 		}
 		method4239();
 		if (GlRenderer.enabled) {
-			method2314(arg3, arg4, arg0, arg2, true);
-			arg2 = anInt983;
-			arg4 = anInt773;
-			arg3 = anInt4055;
-			arg0 = anInt5377;
+			fillRect(width, y, height, x, true);
+			x = componentX;
+			y = componentY;
+			width = componentWidth;
+			height = componentHeight;
 		}
-		@Pc(59) int local59;
-		@Pc(57) int local57;
+		@Pc(59) int pitch;
+		@Pc(57) int yaw;
 		if (Camera.cameraType == 1) {
-			local57 = Camera.anInt5161 + (int) Camera.yawTarget & 0x7FF;
-			local59 = (int) Camera.pitchTarget;
-			if (local59 < Camera.anInt5245 / 256) {
-				local59 = Camera.anInt5245 / 256;
+			yaw = Camera.anInt5161 + (int) Camera.yawTarget & 0x7FF;
+			pitch = (int) Camera.pitchTarget;
+			if (pitch < Camera.anInt5245 / 256) {
+				pitch = Camera.anInt5245 / 256;
 			}
-			if (Camera.customCameraActive[4] && Camera.cameraAmplitude[4] + 128 > local59) {
-				local59 = Camera.cameraAmplitude[4] + 128;
+			if (Camera.customCameraActive[4] && Camera.cameraAmplitude[4] + 128 > pitch) {
+				pitch = Camera.cameraAmplitude[4] + 128;
 			}
-			Camera.method555(Camera.cameraX, arg0, SceneGraph.getTileHeight(Player.plane, PlayerList.self.xFine, PlayerList.self.zFine) - 50, Camera.ZOOM - -(local59 * 3), local57, Camera.cameraZ, local59);
+			Camera.convertOrbitCamToAbsolutePosition(Camera.cameraX, height, SceneGraph.getTileHeight(Player.plane, PlayerList.self.xFine, PlayerList.self.zFine) - 50, Camera.ZOOM - -(pitch * 3), yaw, Camera.cameraZ, pitch);
 		}
-		local57 = Camera.anInt40;
-		local59 = Camera.renderX;
+		yaw = Camera.renderY;
+		pitch = Camera.renderX;
 		@Pc(121) int local121 = Camera.renderZ;
 		@Pc(123) int local123 = Camera.cameraPitch;
 		@Pc(125) int local125 = Camera.cameraYaw;
@@ -262,28 +262,29 @@ public final class ScriptRunner {
 					Camera.renderZ += local171;
 				}
 				if (local127 == 1) {
-					Camera.anInt40 += local171;
+					Camera.renderY += local171;
 				}
 				if (local127 == 0) {
 					Camera.renderX += local171;
 				}
 			}
 		}
+
 		method4302();
 		if (GlRenderer.enabled) {
-			GlRaster.setClip(arg2, arg4, arg2 + arg3, arg4 - -arg0);
+			GlRaster.setClip(x, y, x + width, y - -height);
 			@Pc(248) float local248 = (float) Camera.cameraPitch * 0.17578125F;
 			@Pc(253) float local253 = (float) Camera.cameraYaw * 0.17578125F;
 			if (Camera.cameraType == 3) {
 				local248 = Camera.aFloat15 * 360.0F / 6.2831855F;
 				local253 = Camera.aFloat10 * 360.0F / 6.2831855F;
 			}
-			GlRenderer.method4171(arg2, arg4, arg3, arg0, arg3 / 2 + arg2, arg4 - -(arg0 / 2), local248, local253, anInt5029, anInt5029);
+			GlRenderer.method4171(x, y, width, height, width / 2 + x, y - -(height / 2), local248, local253, anInt5029, anInt5029);
 		} else {
-			SoftwareRaster.setClip(arg2, arg4, arg3 + arg2, arg0 + arg4);
+			SoftwareRaster.setClip(x, y, width + x, height + y);
 			Rasteriser.prepare();
 		}
-		if (Cs1ScriptRunner.aBoolean108 || anInt3751 < arg2 || anInt3751 >= arg3 + arg2 || arg4 > anInt1892 || arg0 + arg4 <= anInt1892) {
+		if (Cs1ScriptRunner.aBoolean108 || anInt3751 < x || anInt3751 >= width + x || y > anInt1892 || height + y <= anInt1892) {
 			RawModel.allowInput = false;
 			MiniMenu.anInt7 = 0;
 		} else {
@@ -292,61 +293,61 @@ public final class ScriptRunner {
 			local171 = Rasteriser.screenUpperX;
 			@Pc(344) int local344 = Rasteriser.screenLowerY;
 			local127 = Rasteriser.screenLowerX;
-			GlModel.anInt3582 = local127 + (local171 - local127) * (-arg2 + anInt3751) / arg3;
+			GlModel.anInt3582 = local127 + (local171 - local127) * (-x + anInt3751) / width;
 			@Pc(361) int local361 = Rasteriser.screenUpperY;
-			RawModel.anInt1053 = (local361 - local344) * (anInt1892 - arg4) / arg0 + local344;
+			RawModel.anInt1053 = (local361 - local344) * (anInt1892 - y) / height + local344;
 		}
 		client.audioLoop();
-		@Pc(387) byte local387 = method4047() == 2 ? (byte) anInt3325 : 1;
+		@Pc(387) byte local387 = getShouldRemoveRoofs() == 2 ? (byte) anInt3325 : 1;
 		if (GlRenderer.enabled) {
 			GlRenderer.restoreLighting();
 			GlRenderer.setDepthTestEnabled(true);
 			GlRenderer.setFogEnabled(true);
 			if (client.gameState == 10) {
-				local171 = FogManager.method2235(Protocol.sceneDelta, Camera.renderZ >> 10, Preferences.brightness, Camera.renderX >> 10);
+				local171 = FogManager.fadeFog(Protocol.sceneDelta, Camera.renderZ >> 10, Preferences.brightness, Camera.renderX >> 10);
 			} else {
-				local171 = FogManager.method2235(Protocol.sceneDelta, PlayerList.self.movementQueueZ[0] >> 3, Preferences.brightness, PlayerList.self.movementQueueX[0] >> 3);
+				local171 = FogManager.fadeFog(Protocol.sceneDelta, PlayerList.self.movementQueueZ[0] >> 3, Preferences.brightness, PlayerList.self.movementQueueX[0] >> 3);
 			}
 			LightingManager.method2394(client.loop, !Preferences.flickeringEffectsOn);
 			GlRenderer.clearColorAndDepthBuffers(local171);
-			MaterialManager.method2731(Camera.cameraPitch, Camera.renderZ, Camera.anInt40, Camera.renderX, Camera.cameraYaw);
+			MaterialManager.method2731(Camera.cameraPitch, Camera.renderZ, Camera.renderY, Camera.renderX, Camera.cameraYaw);
 			GlRenderer.anInt5323 = client.loop;
-			SceneGraph.method2954(Camera.renderX, Camera.anInt40, Camera.renderZ, Camera.cameraPitch, Camera.cameraYaw, aByteArrayArrayArray15, anIntArray205, anIntArray338, anIntArray518, anIntArray134, anIntArray476, Player.plane + 1, local387, PlayerList.self.xFine >> 7, PlayerList.self.zFine >> 7);
+			SceneGraph.method2954(Camera.renderX, Camera.renderY, Camera.renderZ, Camera.cameraPitch, Camera.cameraYaw, removeRoofTiles, anIntArray205, anIntArray338, anIntArray518, anIntArray134, anIntArray476, Player.plane + 1, local387, PlayerList.self.xFine >> 7, PlayerList.self.zFine >> 7);
 			aBoolean299 = true;
 			LightingManager.method2390();
 			MaterialManager.method2731(0, 0, 0, 0, 0);
 			client.audioLoop();
 			method3858();
-			drawOverheads(arg4, arg3, arg2, anInt5029, arg0, anInt5029);
-			MiniMap.method4000(arg3, arg2, arg0, anInt5029, anInt5029, arg4);
+			drawOverheads(y, width, x, anInt5029, height, anInt5029);
+			MiniMap.method4000(width, x, height, anInt5029, anInt5029, y);
 		} else {
-			SoftwareRaster.fillRect(arg2, arg4, arg3, arg0, 0);
-			SceneGraph.method2954(Camera.renderX, Camera.anInt40, Camera.renderZ, Camera.cameraPitch, Camera.cameraYaw, aByteArrayArrayArray15, anIntArray205, anIntArray338, anIntArray518, anIntArray134, anIntArray476, Player.plane + 1, local387, PlayerList.self.xFine >> 7, PlayerList.self.zFine >> 7);
+			SoftwareRaster.fillRect(x, y, width, height, 0);
+			SceneGraph.method2954(Camera.renderX, Camera.renderY, Camera.renderZ, Camera.cameraPitch, Camera.cameraYaw, removeRoofTiles, anIntArray205, anIntArray338, anIntArray518, anIntArray134, anIntArray476, Player.plane + 1, local387, PlayerList.self.xFine >> 7, PlayerList.self.zFine >> 7);
 			client.audioLoop();
 			method3858();
-			drawOverheads(arg4, arg3, arg2, 256, arg0, 256);
-			MiniMap.method4000(arg3, arg2, arg0, 256, 256, arg4);
+			drawOverheads(y, width, x, 256, height, 256);
+			MiniMap.method4000(width, x, height, 256, 256, y);
 		}
 		((Js5GlTextureProvider) Rasteriser.textureProvider).method3239(Protocol.sceneDelta);
-		Player.method2310(arg3, arg4, arg0, arg2);
+		Player.method2310(width, y, height, x);
 		Camera.cameraPitch = local123;
 		Camera.renderZ = local121;
-		Camera.anInt40 = local57;
-		Camera.renderX = local59;
+		Camera.renderY = yaw;
+		Camera.renderX = pitch;
 		Camera.cameraYaw = local125;
 		if (aBoolean43 && client.js5NetQueue.getUrgentRequestCount() == 0) {
 			aBoolean43 = false;
 		}
 		if (aBoolean43) {
 			if (GlRenderer.enabled) {
-				GlRaster.fillRect(arg2, arg4, arg3, arg0, 0);
+				GlRaster.fillRect(x, y, width, height, 0);
 			} else {
-				SoftwareRaster.fillRect(arg2, arg4, arg3, arg0, 0);
+				SoftwareRaster.fillRect(x, y, width, height, 0);
 			}
 			Fonts.drawTextOnScreen(false, LocalizedText.LOADING);
 		}
-		if (!arg1 && !aBoolean43 && !Cs1ScriptRunner.aBoolean108 && arg2 <= anInt3751 && arg3 + arg2 > anInt3751 && arg4 <= anInt1892 && arg0 + arg4 > anInt1892) {
-			MiniMenu.addEntries(arg4, arg3, arg0, arg2, anInt1892, anInt3751);
+		if (!renderOnTop && !aBoolean43 && !Cs1ScriptRunner.aBoolean108 && x <= anInt3751 && width + x > anInt3751 && y <= anInt1892 && height + y > anInt1892) {
+			MiniMenu.addEntries(y, width, height, x, anInt1892, anInt3751);
 		}
 	}
 
@@ -801,7 +802,7 @@ public final class ScriptRunner {
 	}
 
 	@OriginalMember(owner = "client!nk", name = "c", descriptor = "(IZ)V")
-	public static void method3240(@OriginalArg(1) boolean arg0) {
+	public static void method3240(@OriginalArg(1) boolean renderOnTop) {
 		@Pc(7) int local7;
 		@Pc(16) Npc local16;
 		@Pc(107) int local107;
@@ -812,7 +813,7 @@ public final class ScriptRunner {
 		@Pc(171) int local171;
 		for (local7 = 0; local7 < NpcList.size; local7++) {
 			local16 = NpcList.npcs[NpcList.ids[local7]];
-			if (local16 != null && local16.isVisible() && local16.type.toprenderpriority == arg0 && local16.type.isMultiNpcValid()) {
+			if (local16 != null && local16.isVisible() && local16.type.toprenderpriority == renderOnTop && local16.type.isMultiNpcValid()) {
 				@Pc(42) int local42 = local16.getSize();
 				@Pc(97) int local97;
 				if (local42 == 1) {
@@ -852,7 +853,7 @@ public final class ScriptRunner {
 		for (local7 = 0; local7 < NpcList.size; local7++) {
 			local16 = NpcList.npcs[NpcList.ids[local7]];
 			@Pc(262) long local262 = (long) NpcList.ids[local7] << 32 | 0x20000000L;
-			if (local16 != null && local16.isVisible() && local16.type.toprenderpriority == arg0 && local16.type.isMultiNpcValid()) {
+			if (local16 != null && local16.isVisible() && local16.type.toprenderpriority == renderOnTop && local16.type.isMultiNpcValid()) {
 				local107 = local16.getSize();
 				if (local107 == 1) {
 					if ((local16.xFine & 0x7F) == 64 && (local16.zFine & 0x7F) == 64) {
@@ -965,23 +966,23 @@ public final class ScriptRunner {
 	}
 
 	@OriginalMember(owner = "client!wa", name = "o", descriptor = "(I)V")
-	public static void method2218() {
-		@Pc(8) int local8 = method4047();
-		if (local8 == 0) {
-			aByteArrayArrayArray15 = null;
+	public static void setUpRemoveRoofTiles() {
+		@Pc(8) int shouldRemoveRoofs = getShouldRemoveRoofs();
+		if (shouldRemoveRoofs == 0) {
+			removeRoofTiles = null;
 			method3993(0);
-		} else if (local8 == 1) {
-			method960((byte) 0);
+		} else if (shouldRemoveRoofs == 1) {
+			initRemoveRoofTiles((byte) 0);
 			method3993(512);
 			method2608();
 		} else {
-			method960((byte) (anInt3325 - 4 & 0xFF));
+			initRemoveRoofTiles((byte) (anInt3325 - 4 & 0xFF));
 			method3993(2);
 		}
 	}
 
 	@OriginalMember(owner = "client!tc", name = "a", descriptor = "(B)I")
-	public static int method4047() {
+	public static int getShouldRemoveRoofs() {
 		if (neverRemoveRoofs) {
 			return 0;
 		} else if (SceneGraph.allLevelsAreVisible()) {
@@ -1003,14 +1004,14 @@ public final class ScriptRunner {
 	}
 
 	@OriginalMember(owner = "client!cn", name = "a", descriptor = "(BB)V")
-	public static void method960(@OriginalArg(0) byte arg0) {
-		if (aByteArrayArrayArray15 == null) {
-			aByteArrayArrayArray15 = new byte[4][104][104];
+	public static void initRemoveRoofTiles(@OriginalArg(0) byte defaultValue) {
+		if (removeRoofTiles == null) {
+			removeRoofTiles = new byte[4][104][104];
 		}
-		for (@Pc(20) int local20 = 0; local20 < 4; local20++) {
-			for (@Pc(25) int local25 = 0; local25 < 104; local25++) {
-				for (@Pc(32) int local32 = 0; local32 < 104; local32++) {
-					aByteArrayArrayArray15[local20][local25][local32] = arg0;
+		for (@Pc(20) int level = 0; level < 4; level++) {
+			for (@Pc(25) int x = 0; x < 104; x++) {
+				for (@Pc(32) int y = 0; y < 104; y++) {
+					removeRoofTiles[level][x][y] = defaultValue;
 				}
 			}
 		}
@@ -1041,19 +1042,19 @@ public final class ScriptRunner {
 	}
 
 	@OriginalMember(owner = "client!uj", name = "a", descriptor = "(BZII[[[Lclient!bj;I)Z")
-	public static boolean method4348(@OriginalArg(1) boolean arg0, @OriginalArg(2) int arg1, @OriginalArg(3) int arg2, @OriginalArg(4) Tile[][][] arg3, @OriginalArg(5) int arg4) {
+	public static boolean method4348(@OriginalArg(1) boolean arg0, @OriginalArg(2) int x, @OriginalArg(3) int y, @OriginalArg(4) Tile[][][] tiles, @OriginalArg(5) int arg4) {
 		@Pc(14) byte local14 = arg0 ? 1 : (byte) (anInt3325 & 0xFF);
-		if (local14 == aByteArrayArrayArray15[Player.plane][arg1][arg2]) {
+		if (local14 == removeRoofTiles[Player.plane][x][y]) {
 			return false;
-		} else if ((SceneGraph.renderFlags[Player.plane][arg1][arg2] & 0x4) == 0) {
+		} else if ((SceneGraph.tileRenderFlags[Player.plane][x][y] & 0x4) == 0) {
 			return false;
 		} else {
 			@Pc(47) int local47 = 0;
 			@Pc(49) byte local49 = 0;
-			PathFinder.queueX[0] = arg1;
+			PathFinder.queueX[0] = x;
 			@Pc(69) int local69 = local49 + 1;
-			PathFinder.queueZ[0] = arg2;
-			aByteArrayArrayArray15[Player.plane][arg1][arg2] = local14;
+			PathFinder.queueZ[0] = y;
+			removeRoofTiles[Player.plane][x][y] = local14;
 			while (local47 != local69) {
 				@Pc(94) int local94 = PathFinder.queueX[local47] >> 16 & 0xFF;
 				@Pc(102) int local102 = PathFinder.queueX[local47] >> 24 & 0xFF;
@@ -1063,42 +1064,42 @@ public final class ScriptRunner {
 				local47 = local47 + 1 & 0xFFF;
 				@Pc(130) boolean local130 = false;
 				@Pc(132) boolean local132 = false;
-				if ((SceneGraph.renderFlags[Player.plane][local108][local122] & 0x4) == 0) {
+				if ((SceneGraph.tileRenderFlags[Player.plane][local108][local122] & 0x4) == 0) {
 					local130 = true;
 				}
-				@Pc(150) int local150;
+				@Pc(150) int higherLevel;
 				@Pc(191) int local191;
 				label238:
-				for (local150 = Player.plane + 1; local150 <= 3; local150++) {
-					if ((SceneGraph.renderFlags[local150][local108][local122] & 0x8) == 0) {
+				for (higherLevel = Player.plane + 1; higherLevel <= 3; higherLevel++) {
+					if ((SceneGraph.tileRenderFlags[higherLevel][local108][local122] & 0x8) == 0) {
 						@Pc(227) int local227;
 						@Pc(358) int local358;
-						if (local130 && arg3[local150][local108][local122] != null) {
-							if (arg3[local150][local108][local122].wall != null) {
+						if (local130 && tiles[higherLevel][local108][local122] != null) {
+							if (tiles[higherLevel][local108][local122].wall != null) {
 								local191 = SceneGraph.method2251(local94);
-								if (arg3[local150][local108][local122].wall.anInt3049 == local191 || arg3[local150][local108][local122].wall.anInt3052 == local191) {
+								if (tiles[higherLevel][local108][local122].wall.anInt3049 == local191 || tiles[higherLevel][local108][local122].wall.anInt3052 == local191) {
 									continue;
 								}
 								if (local102 != 0) {
 									local227 = SceneGraph.method2251(local102);
-									if (local227 == arg3[local150][local108][local122].wall.anInt3049 || arg3[local150][local108][local122].wall.anInt3052 == local227) {
+									if (local227 == tiles[higherLevel][local108][local122].wall.anInt3049 || tiles[higherLevel][local108][local122].wall.anInt3052 == local227) {
 										continue;
 									}
 								}
 								if (local116 != 0) {
 									local227 = SceneGraph.method2251(local116);
-									if (local227 == arg3[local150][local108][local122].wall.anInt3049 || local227 == arg3[local150][local108][local122].wall.anInt3052) {
+									if (local227 == tiles[higherLevel][local108][local122].wall.anInt3049 || local227 == tiles[higherLevel][local108][local122].wall.anInt3052) {
 										continue;
 									}
 								}
 							}
-							if (arg3[local150][local108][local122].scenery != null) {
-								for (local191 = 0; local191 < arg3[local150][local108][local122].sceneryLen; local191++) {
-									local227 = (int) (arg3[local150][local108][local122].scenery[local191].key >> 14 & 0x3FL);
+							if (tiles[higherLevel][local108][local122].scenery != null) {
+								for (local191 = 0; local191 < tiles[higherLevel][local108][local122].sceneryLen; local191++) {
+									local227 = (int) (tiles[higherLevel][local108][local122].scenery[local191].key >> 14 & 0x3FL);
 									if (local227 == 21) {
 										local227 = 19;
 									}
-									@Pc(352) int local352 = (int) (arg3[local150][local108][local122].scenery[local191].key >> 20 & 0x3L);
+									@Pc(352) int local352 = (int) (tiles[higherLevel][local108][local122].scenery[local191].key >> 20 & 0x3L);
 									local358 = local227 | local352 << 6;
 									if (local358 == local94 || local102 != 0 && local358 == local102 || local116 != 0 && local116 == local358) {
 										continue label238;
@@ -1107,31 +1108,31 @@ public final class ScriptRunner {
 							}
 						}
 						local132 = true;
-						@Pc(395) Tile local395 = arg3[local150][local108][local122];
+						@Pc(395) Tile local395 = tiles[higherLevel][local108][local122];
 						if (local395 != null && local395.sceneryLen > 0) {
 							for (local227 = 0; local227 < local395.sceneryLen; local227++) {
 								@Pc(418) Scenery local418 = local395.scenery[local227];
 								if (local418.xMax != local418.xMin || local418.zMax != local418.zMin) {
 									for (local358 = local418.xMin; local358 <= local418.xMax; local358++) {
 										for (@Pc(450) int local450 = local418.zMin; local450 <= local418.zMax; local450++) {
-											aByteArrayArrayArray15[local150][local358][local450] = local14;
+											removeRoofTiles[higherLevel][local358][local450] = local14;
 										}
 									}
 								}
 							}
 						}
-						aByteArrayArrayArray15[local150][local108][local122] = local14;
+						removeRoofTiles[higherLevel][local108][local122] = local14;
 					}
 				}
 				if (local132) {
 					if (SceneGraph.tileHeights[Player.plane + 1][local108][local122] > anIntArray205[arg4]) {
 						anIntArray205[arg4] = SceneGraph.tileHeights[Player.plane + 1][local108][local122];
 					}
-					local150 = local108 << 7;
-					if (local150 < anIntArray338[arg4]) {
-						anIntArray338[arg4] = local150;
-					} else if (anIntArray518[arg4] < local150) {
-						anIntArray518[arg4] = local150;
+					higherLevel = local108 << 7;
+					if (higherLevel < anIntArray338[arg4]) {
+						anIntArray338[arg4] = higherLevel;
+					} else if (anIntArray518[arg4] < higherLevel) {
+						anIntArray518[arg4] = higherLevel;
 					}
 					local191 = local122 << 7;
 					if (anIntArray476[arg4] > local191) {
@@ -1141,58 +1142,58 @@ public final class ScriptRunner {
 					}
 				}
 				if (!local130) {
-					if (local108 >= 1 && aByteArrayArrayArray15[Player.plane][local108 - 1][local122] != local14) {
+					if (local108 >= 1 && removeRoofTiles[Player.plane][local108 - 1][local122] != local14) {
 						PathFinder.queueX[local69] = local108 - 1 | 0x120000 | 0xD3000000;
 						PathFinder.queueZ[local69] = local122 | 0x130000;
 						local69 = local69 + 1 & 0xFFF;
-						aByteArrayArrayArray15[Player.plane][local108 - 1][local122] = local14;
+						removeRoofTiles[Player.plane][local108 - 1][local122] = local14;
 					}
 					local122++;
 					if (local122 < 104) {
-						if (local108 - 1 >= 0 && local14 != aByteArrayArrayArray15[Player.plane][local108 - 1][local122] && (SceneGraph.renderFlags[Player.plane][local108][local122] & 0x4) == 0 && (SceneGraph.renderFlags[Player.plane][local108 - 1][local122 - 1] & 0x4) == 0) {
+						if (local108 - 1 >= 0 && local14 != removeRoofTiles[Player.plane][local108 - 1][local122] && (SceneGraph.tileRenderFlags[Player.plane][local108][local122] & 0x4) == 0 && (SceneGraph.tileRenderFlags[Player.plane][local108 - 1][local122 - 1] & 0x4) == 0) {
 							PathFinder.queueX[local69] = 0x52000000 | 0x120000 | local108 - 1;
 							PathFinder.queueZ[local69] = local122 | 0x130000;
-							aByteArrayArrayArray15[Player.plane][local108 - 1][local122] = local14;
+							removeRoofTiles[Player.plane][local108 - 1][local122] = local14;
 							local69 = local69 + 1 & 0xFFF;
 						}
-						if (local14 != aByteArrayArrayArray15[Player.plane][local108][local122]) {
+						if (local14 != removeRoofTiles[Player.plane][local108][local122]) {
 							PathFinder.queueX[local69] = local108 | 0x13000000 | 0x520000;
 							PathFinder.queueZ[local69] = local122 | 0x530000;
 							local69 = local69 + 1 & 0xFFF;
-							aByteArrayArrayArray15[Player.plane][local108][local122] = local14;
+							removeRoofTiles[Player.plane][local108][local122] = local14;
 						}
-						if (local108 + 1 < 104 && aByteArrayArrayArray15[Player.plane][local108 + 1][local122] != local14 && (SceneGraph.renderFlags[Player.plane][local108][local122] & 0x4) == 0 && (SceneGraph.renderFlags[Player.plane][local108 + 1][local122 - 1] & 0x4) == 0) {
+						if (local108 + 1 < 104 && removeRoofTiles[Player.plane][local108 + 1][local122] != local14 && (SceneGraph.tileRenderFlags[Player.plane][local108][local122] & 0x4) == 0 && (SceneGraph.tileRenderFlags[Player.plane][local108 + 1][local122 - 1] & 0x4) == 0) {
 							PathFinder.queueX[local69] = 0x92000000 | 0x520000 | local108 + 1;
 							PathFinder.queueZ[local69] = local122 | 0x530000;
-							aByteArrayArrayArray15[Player.plane][local108 + 1][local122] = local14;
+							removeRoofTiles[Player.plane][local108 + 1][local122] = local14;
 							local69 = local69 + 1 & 0xFFF;
 						}
 					}
 					local122--;
-					if (local108 + 1 < 104 && local14 != aByteArrayArrayArray15[Player.plane][local108 + 1][local122]) {
+					if (local108 + 1 < 104 && local14 != removeRoofTiles[Player.plane][local108 + 1][local122]) {
 						PathFinder.queueX[local69] = local108 + 1 | 0x920000 | 0x53000000;
 						PathFinder.queueZ[local69] = local122 | 0x930000;
-						aByteArrayArrayArray15[Player.plane][local108 + 1][local122] = local14;
+						removeRoofTiles[Player.plane][local108 + 1][local122] = local14;
 						local69 = local69 + 1 & 0xFFF;
 					}
 					local122--;
 					if (local122 >= 0) {
-						if (local108 - 1 >= 0 && aByteArrayArrayArray15[Player.plane][local108 - 1][local122] != local14 && (SceneGraph.renderFlags[Player.plane][local108][local122] & 0x4) == 0 && (SceneGraph.renderFlags[Player.plane][local108 - 1][local122 + 1] & 0x4) == 0) {
+						if (local108 - 1 >= 0 && removeRoofTiles[Player.plane][local108 - 1][local122] != local14 && (SceneGraph.tileRenderFlags[Player.plane][local108][local122] & 0x4) == 0 && (SceneGraph.tileRenderFlags[Player.plane][local108 - 1][local122 + 1] & 0x4) == 0) {
 							PathFinder.queueX[local69] = local108 - 1 | 0xD20000 | 0x12000000;
 							PathFinder.queueZ[local69] = local122 | 0xD30000;
-							aByteArrayArrayArray15[Player.plane][local108 - 1][local122] = local14;
+							removeRoofTiles[Player.plane][local108 - 1][local122] = local14;
 							local69 = local69 + 1 & 0xFFF;
 						}
-						if (local14 != aByteArrayArrayArray15[Player.plane][local108][local122]) {
+						if (local14 != removeRoofTiles[Player.plane][local108][local122]) {
 							PathFinder.queueX[local69] = local108 | 0xD20000 | 0x93000000;
 							PathFinder.queueZ[local69] = local122 | 0xD30000;
 							local69 = local69 + 1 & 0xFFF;
-							aByteArrayArrayArray15[Player.plane][local108][local122] = local14;
+							removeRoofTiles[Player.plane][local108][local122] = local14;
 						}
-						if (local108 + 1 < 104 && aByteArrayArrayArray15[Player.plane][local108 + 1][local122] != local14 && (SceneGraph.renderFlags[Player.plane][local108][local122] & 0x4) == 0 && (SceneGraph.renderFlags[Player.plane][local108 + 1][local122 + 1] & 0x4) == 0) {
+						if (local108 + 1 < 104 && removeRoofTiles[Player.plane][local108 + 1][local122] != local14 && (SceneGraph.tileRenderFlags[Player.plane][local108][local122] & 0x4) == 0 && (SceneGraph.tileRenderFlags[Player.plane][local108 + 1][local122 + 1] & 0x4) == 0) {
 							PathFinder.queueX[local69] = local108 + 1 | 0xD2000000 | 0x920000;
 							PathFinder.queueZ[local69] = local122 | 0x930000;
-							aByteArrayArrayArray15[Player.plane][local108 + 1][local122] = local14;
+							removeRoofTiles[Player.plane][local108 + 1][local122] = local14;
 							local69 = local69 + 1 & 0xFFF;
 						}
 					}
@@ -1245,7 +1246,7 @@ public final class ScriptRunner {
 		}
 		@Pc(38) int local38 = SceneGraph.getTileHeight(Player.plane, arg5, arg2) - arg3;
 		@Pc(42) int local42 = arg2 - Camera.renderZ;
-		@Pc(46) int local46 = local38 - Camera.anInt40;
+		@Pc(46) int local46 = local38 - Camera.renderY;
 		@Pc(50) int local50 = arg5 - Camera.renderX;
 		@Pc(54) int local54 = MathUtils.sin[Camera.cameraPitch];
 		@Pc(58) int local58 = MathUtils.cos[Camera.cameraPitch];
@@ -1316,82 +1317,84 @@ public final class ScriptRunner {
 
 	@OriginalMember(owner = "client!uh", name = "f", descriptor = "(I)V")
 	public static void method4302() {
-		if (method4047() != 2) {
+		if (getShouldRemoveRoofs() != 2) {
 			return;
 		}
+
 		@Pc(27) byte local27 = (byte) (anInt3325 - 4 & 0xFF);
 		@Pc(31) int local31 = anInt3325 % 104;
-		@Pc(33) int local33;
-		@Pc(40) int local40;
-		for (local33 = 0; local33 < 4; local33++) {
-			for (local40 = 0; local40 < 104; local40++) {
-				aByteArrayArrayArray15[local33][local31][local40] = local27;
+		@Pc(33) int renderTileX;
+		@Pc(40) int renderTileZ;
+		for (renderTileX = 0; renderTileX < 4; renderTileX++) {
+			for (renderTileZ = 0; renderTileZ < 104; renderTileZ++) {
+				removeRoofTiles[renderTileX][local31][renderTileZ] = local27;
 			}
 		}
 		if (Player.plane == 3) {
 			return;
 		}
-		for (local33 = 0; local33 < 2; local33++) {
-			anIntArray205[local33] = -1000000;
-			anIntArray338[local33] = 1000000;
-			anIntArray518[local33] = 0;
-			anIntArray476[local33] = 1000000;
-			anIntArray134[local33] = 0;
+		for (renderTileX = 0; renderTileX < 2; renderTileX++) {
+			anIntArray205[renderTileX] = -1000000;
+			anIntArray338[renderTileX] = 1000000;
+			anIntArray518[renderTileX] = 0;
+			anIntArray476[renderTileX] = 1000000;
+			anIntArray134[renderTileX] = 0;
 		}
 		if (Camera.cameraType != 1) {
-			local33 = SceneGraph.getTileHeight(Player.plane, Camera.renderX, Camera.renderZ);
-			if (local33 - Camera.anInt40 < 800 && (SceneGraph.renderFlags[Player.plane][Camera.renderX >> 7][Camera.renderZ >> 7] & 0x4) != 0) {
+			renderTileX = SceneGraph.getTileHeight(Player.plane, Camera.renderX, Camera.renderZ);
+			if (renderTileX - Camera.renderY < 800 && (SceneGraph.tileRenderFlags[Player.plane][Camera.renderX >> 7][Camera.renderZ >> 7] & 0x4) != 0) {
 				method4348(false, Camera.renderX >> 7, Camera.renderZ >> 7, SceneGraph.tiles, 1);
 			}
 			return;
 		}
-		if ((SceneGraph.renderFlags[Player.plane][PlayerList.self.xFine >> 7][PlayerList.self.zFine >> 7] & 0x4) != 0) {
+		if ((SceneGraph.tileRenderFlags[Player.plane][PlayerList.self.xFine >> 7][PlayerList.self.zFine >> 7] & 0x4) != 0) {
 			method4348(false, PlayerList.self.xFine >> 7, PlayerList.self.zFine >> 7, SceneGraph.tiles, 0);
 		}
 		if (Camera.cameraPitch >= 310) {
 			return;
 		}
-		@Pc(135) int local135 = PlayerList.self.zFine >> 7;
-		local40 = Camera.renderZ >> 7;
-		@Pc(146) int local146;
-		if (local40 < local135) {
-			local146 = local135 - local40;
+		@Pc(135) int playerTileZ = PlayerList.self.zFine >> 7;
+		renderTileZ = Camera.renderZ >> 7;
+		@Pc(146) int cameraTileDistanceZ;
+		if (renderTileZ < playerTileZ) {
+			cameraTileDistanceZ = playerTileZ - renderTileZ;
 		} else {
-			local146 = local40 - local135;
+			cameraTileDistanceZ = renderTileZ - playerTileZ;
 		}
-		local33 = Camera.renderX >> 7;
-		@Pc(162) int local162 = PlayerList.self.xFine >> 7;
-		@Pc(174) int local174;
-		if (local162 > local33) {
-			local174 = local162 - local33;
+		renderTileX = Camera.renderX >> 7;
+		@Pc(162) int playerTileX = PlayerList.self.xFine >> 7;
+		@Pc(174) int cameraTileDistanceX;
+		if (playerTileX > renderTileX) {
+			cameraTileDistanceX = playerTileX - renderTileX;
 		} else {
-			local174 = local33 - local162;
+			cameraTileDistanceX = renderTileX - playerTileX;
 		}
 		@Pc(192) int local192;
 		@Pc(186) int local186;
-		if (local174 <= local146) {
+		if (cameraTileDistanceX <= cameraTileDistanceZ) {
 			local186 = 32768;
-			local192 = local174 * 65536 / local146;
-			while (local40 != local135) {
-				if (local40 < local135) {
-					local40++;
-				} else if (local40 > local135) {
-					local40--;
+			local192 = cameraTileDistanceX * 65536 / cameraTileDistanceZ;
+			while (renderTileZ != playerTileZ) {
+				if (renderTileZ < playerTileZ) {
+					renderTileZ++;
+				} else {
+					renderTileZ--;
 				}
-				if ((SceneGraph.renderFlags[Player.plane][local33][local40] & 0x4) != 0) {
-					method4348(false, local33, local40, SceneGraph.tiles, 1);
+
+				if ((SceneGraph.tileRenderFlags[Player.plane][renderTileX][renderTileZ] & 0x4) != 0) {
+					method4348(false, renderTileX, renderTileZ, SceneGraph.tiles, 1);
 					break;
 				}
 				local186 += local192;
 				if (local186 >= 65536) {
-					if (local162 > local33) {
-						local33++;
-					} else if (local162 < local33) {
-						local33--;
+					if (playerTileX > renderTileX) {
+						renderTileX++;
+					} else if (playerTileX < renderTileX) {
+						renderTileX--;
 					}
 					local186 -= 65536;
-					if ((SceneGraph.renderFlags[Player.plane][local33][local40] & 0x4) != 0) {
-						method4348(false, local33, local40, SceneGraph.tiles, 1);
+					if ((SceneGraph.tileRenderFlags[Player.plane][renderTileX][renderTileZ] & 0x4) != 0) {
+						method4348(false, renderTileX, renderTileZ, SceneGraph.tiles, 1);
 						break;
 					}
 				}
@@ -1399,27 +1402,27 @@ public final class ScriptRunner {
 			return;
 		}
 		local186 = 32768;
-		local192 = local146 * 65536 / local174;
-		while (local162 != local33) {
-			if (local162 > local33) {
-				local33++;
-			} else if (local33 > local162) {
-				local33--;
+		local192 = cameraTileDistanceZ * 65536 / cameraTileDistanceX;
+		while (playerTileX != renderTileX) {
+			if (playerTileX > renderTileX) {
+				renderTileX++;
+			} else {
+				renderTileX--;
 			}
-			if ((SceneGraph.renderFlags[Player.plane][local33][local40] & 0x4) != 0) {
-				method4348(false, local33, local40, SceneGraph.tiles, 1);
+			if ((SceneGraph.tileRenderFlags[Player.plane][renderTileX][renderTileZ] & 0x4) != 0) {
+				method4348(false, renderTileX, renderTileZ, SceneGraph.tiles, 1);
 				break;
 			}
 			local186 += local192;
 			if (local186 >= 65536) {
-				if (local40 < local135) {
-					local40++;
-				} else if (local135 < local40) {
-					local40--;
+				if (renderTileZ < playerTileZ) {
+					renderTileZ++;
+				} else if (playerTileZ < renderTileZ) {
+					renderTileZ--;
 				}
 				local186 -= 65536;
-				if ((SceneGraph.renderFlags[Player.plane][local33][local40] & 0x4) != 0) {
-					method4348(false, local33, local40, SceneGraph.tiles, 1);
+				if ((SceneGraph.tileRenderFlags[Player.plane][renderTileX][renderTileZ] & 0x4) != 0) {
+					method4348(false, renderTileX, renderTileZ, SceneGraph.tiles, 1);
 					break;
 				}
 			}
@@ -5030,7 +5033,7 @@ public final class ScriptRunner {
 														Preferences.setAllVisibleLevels(intStack[isp] == 1);
 														LocTypeList.clear();
 														method2742();
-														method2218();
+														setUpRemoveRoofTiles();
 														Preferences.write(GameShell.signLink);
 														Preferences.sentToServer = false;
 														continue;
@@ -5038,7 +5041,7 @@ public final class ScriptRunner {
 													if (opcode == 6003) {
 														isp--;
 														Preferences.removeRoofsSelectively = intStack[isp] == 1;
-														method2218();
+														setUpRemoveRoofTiles();
 														Preferences.write(GameShell.signLink);
 														Preferences.sentToServer = false;
 														continue;
@@ -5221,7 +5224,7 @@ public final class ScriptRunner {
 													if (opcode == 6021) {
 														isp--;
 														neverRemoveRoofs = intStack[isp] == 1;
-														method2218();
+														setUpRemoveRoofTiles();
 														continue;
 													}
 													if (opcode == 6023) {
@@ -5403,9 +5406,9 @@ public final class ScriptRunner {
 														continue;
 													}
 													if (opcode == 6203) {
-														method2314(InterfaceList.aClass13_26.width, 0, InterfaceList.aClass13_26.height, 0, false);
-														intStack[isp++] = anInt4055;
-														intStack[isp++] = anInt5377;
+														fillRect(InterfaceList.aClass13_26.width, 0, InterfaceList.aClass13_26.height, 0, false);
+														intStack[isp++] = componentWidth;
+														intStack[isp++] = componentHeight;
 														continue;
 													}
 													if (opcode == 6204) {

--- a/client/src/main/java/rt4/ScriptRunner.java
+++ b/client/src/main/java/rt4/ScriptRunner.java
@@ -270,7 +270,7 @@ public final class ScriptRunner {
 			}
 		}
 
-		method4302();
+		handleRemoveRoofsSelectively();
 		if (GlRenderer.enabled) {
 			GlRaster.setClip(x, y, x + width, y - -height);
 			@Pc(248) float local248 = (float) Camera.cameraPitch * 0.17578125F;
@@ -1316,33 +1316,33 @@ public final class ScriptRunner {
 	}
 
 	@OriginalMember(owner = "client!uh", name = "f", descriptor = "(I)V")
-	public static void method4302() {
+	public static void handleRemoveRoofsSelectively() {
 		if (getShouldRemoveRoofs() != 2) {
 			return;
 		}
 
 		@Pc(27) byte local27 = (byte) (anInt3325 - 4 & 0xFF);
 		@Pc(31) int local31 = anInt3325 % 104;
-		@Pc(33) int renderTileX;
-		@Pc(40) int renderTileZ;
-		for (renderTileX = 0; renderTileX < 4; renderTileX++) {
-			for (renderTileZ = 0; renderTileZ < 104; renderTileZ++) {
-				removeRoofTiles[renderTileX][local31][renderTileZ] = local27;
+		@Pc(33) int level;
+		@Pc(40) int tileZ;
+		for (level = 0; level < 4; level++) {
+			for (tileZ = 0; tileZ < 104; tileZ++) {
+				removeRoofTiles[level][local31][tileZ] = local27;
 			}
 		}
 		if (Player.plane == 3) {
 			return;
 		}
-		for (renderTileX = 0; renderTileX < 2; renderTileX++) {
-			anIntArray205[renderTileX] = -1000000;
-			anIntArray338[renderTileX] = 1000000;
-			anIntArray518[renderTileX] = 0;
-			anIntArray476[renderTileX] = 1000000;
-			anIntArray134[renderTileX] = 0;
+		for (level = 0; level < 2; level++) {
+			anIntArray205[level] = -1000000;
+			anIntArray338[level] = 1000000;
+			anIntArray518[level] = 0;
+			anIntArray476[level] = 1000000;
+			anIntArray134[level] = 0;
 		}
 		if (Camera.cameraType != 1) {
-			renderTileX = SceneGraph.getTileHeight(Player.plane, Camera.renderX, Camera.renderZ);
-			if (renderTileX - Camera.renderY < 800 && (SceneGraph.tileRenderFlags[Player.plane][Camera.renderX >> 7][Camera.renderZ >> 7] & 0x4) != 0) {
+			level = SceneGraph.getTileHeight(Player.plane, Camera.renderX, Camera.renderZ);
+			if (level - Camera.renderY < 800 && (SceneGraph.tileRenderFlags[Player.plane][Camera.renderX >> 7][Camera.renderZ >> 7] & 0x4) != 0) {
 				method4348(false, Camera.renderX >> 7, Camera.renderZ >> 7, SceneGraph.tiles, 1);
 			}
 			return;
@@ -1353,21 +1353,27 @@ public final class ScriptRunner {
 		if (Camera.cameraPitch >= 310) {
 			return;
 		}
-		@Pc(135) int playerTileZ = PlayerList.self.zFine >> 7;
-		renderTileZ = Camera.renderZ >> 7;
-		@Pc(146) int cameraTileDistanceZ;
-		if (renderTileZ < playerTileZ) {
-			cameraTileDistanceZ = playerTileZ - renderTileZ;
-		} else {
-			cameraTileDistanceZ = renderTileZ - playerTileZ;
+		int renderTileZ = Camera.renderZ >> 7;
+		int renderTileX = Camera.renderX >> 7;
+
+		if (renderTileZ < 0 || renderTileZ >= 104 || renderTileX < 0 || renderTileX >= 104)
+		{
+			return;
 		}
-		renderTileX = Camera.renderX >> 7;
+
+		@Pc(135) int playerTileZ = PlayerList.self.zFine >> 7;
 		@Pc(162) int playerTileX = PlayerList.self.xFine >> 7;
 		@Pc(174) int cameraTileDistanceX;
 		if (playerTileX > renderTileX) {
 			cameraTileDistanceX = playerTileX - renderTileX;
 		} else {
 			cameraTileDistanceX = renderTileX - playerTileX;
+		}
+		@Pc(146) int cameraTileDistanceZ;
+		if (renderTileZ < playerTileZ) {
+			cameraTileDistanceZ = playerTileZ - renderTileZ;
+		} else {
+			cameraTileDistanceZ = renderTileZ - playerTileZ;
 		}
 		@Pc(192) int local192;
 		@Pc(186) int local186;
@@ -1430,7 +1436,7 @@ public final class ScriptRunner {
 	}
 
 	@OriginalMember(owner = "client!lf", name = "a", descriptor = "(I)V")
-	public static void method2742() {
+	public static void setLoadingState() {
 		if (client.gameState == 10 && GlRenderer.enabled) {
 			client.setGameState(28);
 		}
@@ -5020,7 +5026,7 @@ public final class ScriptRunner {
 														if (GlRenderer.enabled) {
 															FogManager.setInstantFade();
 															if (!Preferences.highDetailLighting) {
-																method2742();
+																setLoadingState();
 															}
 														}
 														ObjTypeList.clearSprites();
@@ -5032,7 +5038,7 @@ public final class ScriptRunner {
 														isp--;
 														Preferences.setAllVisibleLevels(intStack[isp] == 1);
 														LocTypeList.clear();
-														method2742();
+														setLoadingState();
 														setUpRemoveRoofTiles();
 														Preferences.write(GameShell.signLink);
 														Preferences.sentToServer = false;
@@ -5049,7 +5055,7 @@ public final class ScriptRunner {
 													if (opcode == 6005) {
 														isp--;
 														Preferences.showGroundDecorations = intStack[isp] == 1;
-														method2742();
+														setLoadingState();
 														Preferences.write(GameShell.signLink);
 														Preferences.sentToServer = false;
 														continue;
@@ -5123,7 +5129,7 @@ public final class ScriptRunner {
 																Rasteriser.setBrightness(0.6F);
 															}
 														}
-														method2742();
+														setLoadingState();
 														Preferences.write(GameShell.signLink);
 														Preferences.sentToServer = false;
 														continue;
@@ -5132,7 +5138,7 @@ public final class ScriptRunner {
 														isp--;
 														Preferences.highWaterDetail = intStack[isp] == 1;
 														if (GlRenderer.enabled) {
-															method2742();
+															setLoadingState();
 														}
 														Preferences.write(GameShell.signLink);
 														Preferences.sentToServer = false;

--- a/client/src/main/java/rt4/SoftwareRaster.java
+++ b/client/src/main/java/rt4/SoftwareRaster.java
@@ -43,35 +43,35 @@ public final class SoftwareRaster {
 	}
 
 	@OriginalMember(owner = "client!kb", name = "a", descriptor = "(IIIII)V")
-	public static void drawRect(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int color) {
-		drawHorizontalLine(arg0, arg1, arg2, color);
-		drawHorizontalLine(arg0, arg1 + arg3 - 1, arg2, color);
-		drawVerticalLine(arg0, arg1, arg3, color);
-		drawVerticalLine(arg0 + arg2 - 1, arg1, arg3, color);
+	public static void drawRect(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int width, @OriginalArg(3) int height, @OriginalArg(4) int color) {
+		drawHorizontalLine(x, y, width, color);
+		drawHorizontalLine(x, y + height - 1, width, color);
+		drawVerticalLine(x, y, height, color);
+		drawVerticalLine(x + width - 1, y, height, color);
 	}
 
 	@OriginalMember(owner = "client!kb", name = "a", descriptor = "(IIIIII)V")
-	public static void fillRectAlpha(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5) {
-		if (arg0 < clipLeft) {
-			arg2 -= clipLeft - arg0;
-			arg0 = clipLeft;
+	public static void fillRectAlpha(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int width, @OriginalArg(3) int height, @OriginalArg(4) int color, @OriginalArg(5) int alpha) {
+		if (x < clipLeft) {
+			width -= clipLeft - x;
+			x = clipLeft;
 		}
-		if (arg1 < clipTop) {
-			arg3 -= clipTop - arg1;
-			arg1 = clipTop;
+		if (y < clipTop) {
+			height -= clipTop - y;
+			y = clipTop;
 		}
-		if (arg0 + arg2 > clipRight) {
-			arg2 = clipRight - arg0;
+		if (x + width > clipRight) {
+			width = clipRight - x;
 		}
-		if (arg1 + arg3 > clipBottom) {
-			arg3 = clipBottom - arg1;
+		if (y + height > clipBottom) {
+			height = clipBottom - y;
 		}
-		@Pc(59) int local59 = ((arg4 & 0xFF00FF) * arg5 >> 8 & 0xFF00FF) + ((arg4 & 0xFF00) * arg5 >> 8 & 0xFF00);
-		@Pc(63) int local63 = 256 - arg5;
-		@Pc(67) int local67 = width - arg2;
-		@Pc(73) int local73 = arg0 + arg1 * width;
-		for (@Pc(75) int local75 = 0; local75 < arg3; local75++) {
-			for (@Pc(81) int local81 = -arg2; local81 < 0; local81++) {
+		@Pc(59) int local59 = ((color & 0xFF00FF) * alpha >> 8 & 0xFF00FF) + ((color & 0xFF00) * alpha >> 8 & 0xFF00);
+		@Pc(63) int local63 = 256 - alpha;
+		@Pc(67) int local67 = SoftwareRaster.width - width;
+		@Pc(73) int local73 = x + y * SoftwareRaster.width;
+		for (@Pc(75) int local75 = 0; local75 < height; local75++) {
+			for (@Pc(81) int local81 = -width; local81 < 0; local81++) {
 				@Pc(87) int local87 = pixels[local73];
 				@Pc(107) int local107 = ((local87 & 0xFF00FF) * local63 >> 8 & 0xFF00FF) + ((local87 & 0xFF00) * local63 >> 8 & 0xFF00);
 				pixels[local73++] = local59 + local107;
@@ -97,21 +97,21 @@ public final class SoftwareRaster {
 	}
 
 	@OriginalMember(owner = "client!kb", name = "b", descriptor = "(IIIIII)V")
-	public static void method2487(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5) {
-		method2493(arg0, arg1, arg2, arg4, arg5);
-		method2493(arg0, arg1 + arg3 - 1, arg2, arg4, arg5);
-		if (arg3 >= 3) {
-			method2499(arg0, arg1 + 1, arg3 - 2, arg4, arg5);
-			method2499(arg0 + arg2 - 1, arg1 + 1, arg3 - 2, arg4, arg5);
+	public static void drawRectAlpha(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int width, @OriginalArg(3) int height, @OriginalArg(4) int color, @OriginalArg(5) int alpha) {
+		drawHorizontalLineAlpha(x, y, width, color, alpha);
+		drawHorizontalLineAlpha(x, y + height - 1, width, color, alpha);
+		if (height >= 3) {
+			drawVerticalLineAlpha(x, y + 1, height - 2, color, alpha);
+			drawVerticalLineAlpha(x + width - 1, y + 1, height - 2, color, alpha);
 		}
 	}
 
 	@OriginalMember(owner = "client!kb", name = "a", descriptor = "([I)V")
-	public static void restoreClip(@OriginalArg(0) int[] arg0) {
-		clipLeft = arg0[0];
-		clipTop = arg0[1];
-		clipRight = arg0[2];
-		clipBottom = arg0[3];
+	public static void restoreClip(@OriginalArg(0) int[] clipSides) {
+		clipLeft = clipSides[0];
+		clipTop = clipSides[1];
+		clipRight = clipSides[2];
+		clipBottom = clipSides[3];
 		method2482();
 	}
 
@@ -186,23 +186,23 @@ public final class SoftwareRaster {
 	}
 
 	@OriginalMember(owner = "client!kb", name = "b", descriptor = "(IIIII)V")
-	private static void method2493(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
-		if (arg1 < clipTop || arg1 >= clipBottom) {
+	private static void drawHorizontalLineAlpha(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int length, @OriginalArg(3) int color, @OriginalArg(4) int alpha) {
+		if (y < clipTop || y >= clipBottom) {
 			return;
 		}
-		if (arg0 < clipLeft) {
-			arg2 -= clipLeft - arg0;
-			arg0 = clipLeft;
+		if (x < clipLeft) {
+			length -= clipLeft - x;
+			x = clipLeft;
 		}
-		if (arg0 + arg2 > clipRight) {
-			arg2 = clipRight - arg0;
+		if (x + length > clipRight) {
+			length = clipRight - x;
 		}
-		@Pc(30) int local30 = 256 - arg4;
-		@Pc(38) int local38 = (arg3 >> 16 & 0xFF) * arg4;
-		@Pc(46) int local46 = (arg3 >> 8 & 0xFF) * arg4;
-		@Pc(52) int local52 = (arg3 & 0xFF) * arg4;
-		@Pc(58) int local58 = arg0 + arg1 * width;
-		for (@Pc(60) int local60 = 0; local60 < arg2; local60++) {
+		@Pc(30) int local30 = 256 - alpha;
+		@Pc(38) int local38 = (color >> 16 & 0xFF) * alpha;
+		@Pc(46) int local46 = (color >> 8 & 0xFF) * alpha;
+		@Pc(52) int local52 = (color & 0xFF) * alpha;
+		@Pc(58) int local58 = x + y * width;
+		for (@Pc(60) int local60 = 0; local60 < length; local60++) {
 			@Pc(73) int local73 = (pixels[local58] >> 16 & 0xFF) * local30;
 			@Pc(83) int local83 = (pixels[local58] >> 8 & 0xFF) * local30;
 			@Pc(91) int local91 = (pixels[local58] & 0xFF) * local30;
@@ -212,9 +212,9 @@ public final class SoftwareRaster {
 	}
 
 	@OriginalMember(owner = "client!kb", name = "c", descriptor = "(IIIIII)V")
-	public static void method2494(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4, @OriginalArg(5) int arg5) {
-		@Pc(3) int local3 = arg2 - arg0;
-		@Pc(7) int local7 = arg3 - arg1;
+	public static void renderLine(@OriginalArg(0) int x0, @OriginalArg(1) int y0, @OriginalArg(2) int x1, @OriginalArg(3) int y1, @OriginalArg(4) int color, @OriginalArg(5) int lineWidth) {
+		@Pc(3) int local3 = x1 - x0;
+		@Pc(7) int local7 = y1 - y0;
 		@Pc(14) int local14 = local3 >= 0 ? local3 : -local3;
 		@Pc(21) int local21 = local7 >= 0 ? local7 : -local7;
 		@Pc(23) int local23 = local14;
@@ -231,12 +231,12 @@ public final class SoftwareRaster {
 		} else {
 			local43 = -local43;
 		}
-		@Pc(59) int local59 = arg5 * local43 >> 17;
-		@Pc(67) int local67 = arg5 * local43 + 1 >> 17;
-		@Pc(73) int local73 = arg5 * local37 >> 17;
-		@Pc(81) int local81 = arg5 * local37 + 1 >> 17;
-		@Pc(85) int local85 = arg0 - Rasteriser.getOffsetRemainder();
-		@Pc(89) int local89 = arg1 - Rasteriser.getOffset();
+		@Pc(59) int local59 = lineWidth * local43 >> 17;
+		@Pc(67) int local67 = lineWidth * local43 + 1 >> 17;
+		@Pc(73) int local73 = lineWidth * local37 >> 17;
+		@Pc(81) int local81 = lineWidth * local37 + 1 >> 17;
+		@Pc(85) int local85 = x0 - Rasteriser.getOffsetRemainder();
+		@Pc(89) int local89 = y0 - Rasteriser.getOffset();
 		@Pc(93) int local93 = local85 + local59;
 		@Pc(97) int local97 = local85 - local67;
 		@Pc(103) int local103 = local85 + local3 - local67;
@@ -246,32 +246,32 @@ public final class SoftwareRaster {
 		@Pc(123) int local123 = local89 + local7 - local81;
 		@Pc(129) int local129 = local89 + local7 + local73;
 		Rasteriser.testPoints(local93, local97, local103);
-		Rasteriser.fillTriangle(local113, local117, local123, local93, local97, local103, arg4);
+		Rasteriser.fillTriangle(local113, local117, local123, local93, local97, local103, color);
 		Rasteriser.testPoints(local93, local103, local109);
-		Rasteriser.fillTriangle(local113, local123, local129, local93, local103, local109, arg4);
+		Rasteriser.fillTriangle(local113, local123, local129, local93, local103, local109, color);
 	}
 
 	@OriginalMember(owner = "client!kb", name = "c", descriptor = "(IIIII)V")
-	public static void fillRect(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
-		if (arg0 < clipLeft) {
-			arg2 -= clipLeft - arg0;
-			arg0 = clipLeft;
+	public static void fillRect(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int width, @OriginalArg(3) int height, @OriginalArg(4) int color) {
+		if (x < clipLeft) {
+			width -= clipLeft - x;
+			x = clipLeft;
 		}
-		if (arg1 < clipTop) {
-			arg3 -= clipTop - arg1;
-			arg1 = clipTop;
+		if (y < clipTop) {
+			height -= clipTop - y;
+			y = clipTop;
 		}
-		if (arg0 + arg2 > clipRight) {
-			arg2 = clipRight - arg0;
+		if (x + width > clipRight) {
+			width = clipRight - x;
 		}
-		if (arg1 + arg3 > clipBottom) {
-			arg3 = clipBottom - arg1;
+		if (y + height > clipBottom) {
+			height = clipBottom - y;
 		}
-		@Pc(43) int local43 = width - arg2;
-		@Pc(49) int local49 = arg0 + arg1 * width;
-		for (@Pc(52) int local52 = -arg3; local52 < 0; local52++) {
-			for (@Pc(57) int local57 = -arg2; local57 < 0; local57++) {
-				pixels[local49++] = arg4;
+		@Pc(43) int local43 = SoftwareRaster.width - width;
+		@Pc(49) int local49 = x + y * SoftwareRaster.width;
+		for (@Pc(52) int local52 = -height; local52 < 0; local52++) {
+			for (@Pc(57) int local57 = -width; local57 < 0; local57++) {
+				pixels[local49++] = color;
 			}
 			local49 += local43;
 		}
@@ -299,11 +299,11 @@ public final class SoftwareRaster {
 	}
 
 	@OriginalMember(owner = "client!kb", name = "b", descriptor = "([I)V")
-	public static void saveClip(@OriginalArg(0) int[] arg0) {
-		arg0[0] = clipLeft;
-		arg0[1] = clipTop;
-		arg0[2] = clipRight;
-		arg0[3] = clipBottom;
+	public static void saveClip(@OriginalArg(0) int[] clipArray) {
+		clipArray[0] = clipLeft;
+		clipArray[1] = clipTop;
+		clipArray[2] = clipRight;
+		clipArray[3] = clipBottom;
 	}
 
 	@OriginalMember(owner = "client!kb", name = "d", descriptor = "(IIII)V")
@@ -324,23 +324,23 @@ public final class SoftwareRaster {
 	}
 
 	@OriginalMember(owner = "client!kb", name = "d", descriptor = "(IIIII)V")
-	private static void method2499(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
-		if (arg0 < clipLeft || arg0 >= clipRight) {
+	private static void drawVerticalLineAlpha(@OriginalArg(0) int x, @OriginalArg(1) int y, @OriginalArg(2) int length, @OriginalArg(3) int color, @OriginalArg(4) int alpha) {
+		if (x < clipLeft || x >= clipRight) {
 			return;
 		}
-		if (arg1 < clipTop) {
-			arg2 -= clipTop - arg1;
-			arg1 = clipTop;
+		if (y < clipTop) {
+			length -= clipTop - y;
+			y = clipTop;
 		}
-		if (arg1 + arg2 > clipBottom) {
-			arg2 = clipBottom - arg1;
+		if (y + length > clipBottom) {
+			length = clipBottom - y;
 		}
-		@Pc(30) int local30 = 256 - arg4;
-		@Pc(38) int local38 = (arg3 >> 16 & 0xFF) * arg4;
-		@Pc(46) int local46 = (arg3 >> 8 & 0xFF) * arg4;
-		@Pc(52) int local52 = (arg3 & 0xFF) * arg4;
-		@Pc(58) int local58 = arg0 + arg1 * width;
-		for (@Pc(60) int local60 = 0; local60 < arg2; local60++) {
+		@Pc(30) int local30 = 256 - alpha;
+		@Pc(38) int local38 = (color >> 16 & 0xFF) * alpha;
+		@Pc(46) int local46 = (color >> 8 & 0xFF) * alpha;
+		@Pc(52) int local52 = (color & 0xFF) * alpha;
+		@Pc(58) int local58 = x + y * width;
+		for (@Pc(60) int local60 = 0; local60 < length; local60++) {
 			@Pc(73) int local73 = (pixels[local58] >> 16 & 0xFF) * local30;
 			@Pc(83) int local83 = (pixels[local58] >> 8 & 0xFF) * local30;
 			@Pc(91) int local91 = (pixels[local58] & 0xFF) * local30;
@@ -351,71 +351,71 @@ public final class SoftwareRaster {
 	}
 
 	@OriginalMember(owner = "client!kb", name = "e", descriptor = "(IIIII)V")
-	public static void method2500(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2, @OriginalArg(3) int arg3, @OriginalArg(4) int arg4) {
-		arg2 -= arg0;
-		arg3 -= arg1;
-		if (arg3 == 0) {
-			if (arg2 >= 0) {
-				drawHorizontalLine(arg0, arg1, arg2 + 1, arg4);
+	public static void renderLine(@OriginalArg(0) int x0, @OriginalArg(1) int y0, @OriginalArg(2) int x1, @OriginalArg(3) int y1, @OriginalArg(4) int color) {
+		x1 -= x0;
+		y1 -= y0;
+		if (y1 == 0) {
+			if (x1 >= 0) {
+				drawHorizontalLine(x0, y0, x1 + 1, color);
 			} else {
-				drawHorizontalLine(arg0 + arg2, arg1, 1 - arg2, arg4);
+				drawHorizontalLine(x0 + x1, y0, 1 - x1, color);
 			}
-		} else if (arg2 != 0) {
-			if (arg2 + arg3 < 0) {
-				arg0 += arg2;
-				arg2 = -arg2;
-				arg1 += arg3;
-				arg3 = -arg3;
+		} else if (x1 != 0) {
+			if (x1 + y1 < 0) {
+				x0 += x1;
+				x1 = -x1;
+				y0 += y1;
+				y1 = -y1;
 			}
 			@Pc(96) int local96;
 			@Pc(127) int local127;
-			if (arg2 > arg3) {
-				arg1 <<= 0x10;
-				arg1 += 32768;
-				@Pc(86) int local86 = arg3 << 16;
-				local96 = (int) Math.floor((double) local86 / (double) arg2 + 0.5D);
-				arg2 += arg0;
-				if (arg0 < clipLeft) {
-					arg1 += local96 * (clipLeft - arg0);
-					arg0 = clipLeft;
+			if (x1 > y1) {
+				y0 <<= 0x10;
+				y0 += 32768;
+				@Pc(86) int local86 = y1 << 16;
+				local96 = (int) Math.floor((double) local86 / (double) x1 + 0.5D);
+				x1 += x0;
+				if (x0 < clipLeft) {
+					y0 += local96 * (clipLeft - x0);
+					x0 = clipLeft;
 				}
-				if (arg2 >= clipRight) {
-					arg2 = clipRight - 1;
+				if (x1 >= clipRight) {
+					x1 = clipRight - 1;
 				}
-				while (arg0 <= arg2) {
-					local127 = arg1 >> 16;
+				while (x0 <= x1) {
+					local127 = y0 >> 16;
 					if (local127 >= clipTop && local127 < clipBottom) {
-						pixels[arg0 + local127 * width] = arg4;
+						pixels[x0 + local127 * width] = color;
 					}
-					arg1 += local96;
-					arg0++;
+					y0 += local96;
+					x0++;
 				}
 			} else {
-				arg0 <<= 0x10;
-				arg0 += 32768;
-				@Pc(160) int local160 = arg2 << 16;
-				local96 = (int) Math.floor((double) local160 / (double) arg3 + 0.5D);
-				arg3 += arg1;
-				if (arg1 < clipTop) {
-					arg0 += local96 * (clipTop - arg1);
-					arg1 = clipTop;
+				x0 <<= 0x10;
+				x0 += 32768;
+				@Pc(160) int local160 = x1 << 16;
+				local96 = (int) Math.floor((double) local160 / (double) y1 + 0.5D);
+				y1 += y0;
+				if (y0 < clipTop) {
+					x0 += local96 * (clipTop - y0);
+					y0 = clipTop;
 				}
-				if (arg3 >= clipBottom) {
-					arg3 = clipBottom - 1;
+				if (y1 >= clipBottom) {
+					y1 = clipBottom - 1;
 				}
-				while (arg1 <= arg3) {
-					local127 = arg0 >> 16;
+				while (y0 <= y1) {
+					local127 = x0 >> 16;
 					if (local127 >= clipLeft && local127 < clipRight) {
-						pixels[local127 + arg1 * width] = arg4;
+						pixels[local127 + y0 * width] = color;
 					}
-					arg0 += local96;
-					arg1++;
+					x0 += local96;
+					y0++;
 				}
 			}
-		} else if (arg3 >= 0) {
-			drawVerticalLine(arg0, arg1, arg3 + 1, arg4);
+		} else if (y1 >= 0) {
+			drawVerticalLine(x0, y0, y1 + 1, color);
 		} else {
-			drawVerticalLine(arg0, arg1 + arg3, -arg3 + 1, arg4);
+			drawVerticalLine(x0, y0 + y1, -y1 + 1, color);
 		}
 	}
 
@@ -594,7 +594,7 @@ public final class SoftwareRaster {
 	}
 
 	@OriginalMember(owner = "client!kb", name = "c", descriptor = "()V")
-	public static void method2503() {
+	public static void setFullClip() {
 		clipLeft = 0;
 		clipTop = 0;
 		clipRight = width;

--- a/client/src/main/java/rt4/Tile.java
+++ b/client/src/main/java/rt4/Tile.java
@@ -62,21 +62,21 @@ public final class Tile extends Node {
 	public final int[] interiorFlags = new int[5];
 
 	@OriginalMember(owner = "client!bj", name = "H", descriptor = "I")
-	public final int anInt666;
+	public final int y;
 
 	@OriginalMember(owner = "client!bj", name = "W", descriptor = "I")
-	public int anInt672;
+	public int level;
 
 	@OriginalMember(owner = "client!bj", name = "Q", descriptor = "I")
-	public final int anInt668;
+	public final int plane;
 
 	@OriginalMember(owner = "client!bj", name = "R", descriptor = "I")
-	public final int anInt669;
+	public final int x;
 
 	@OriginalMember(owner = "client!bj", name = "<init>", descriptor = "(III)V")
-	public Tile(@OriginalArg(0) int arg0, @OriginalArg(1) int arg1, @OriginalArg(2) int arg2) {
-		this.anInt666 = arg2;
-		this.anInt668 = this.anInt672 = arg0;
-		this.anInt669 = arg1;
+	public Tile(@OriginalArg(0) int level, @OriginalArg(1) int x, @OriginalArg(2) int y) {
+		this.y = y;
+		this.plane = this.level = level;
+		this.x = x;
 	}
 }

--- a/client/src/main/java/rt4/Tile.java
+++ b/client/src/main/java/rt4/Tile.java
@@ -62,7 +62,7 @@ public final class Tile extends Node {
 	public final int[] interiorFlags = new int[5];
 
 	@OriginalMember(owner = "client!bj", name = "H", descriptor = "I")
-	public final int y;
+	public final int z;
 
 	@OriginalMember(owner = "client!bj", name = "W", descriptor = "I")
 	public int level;
@@ -74,8 +74,8 @@ public final class Tile extends Node {
 	public final int x;
 
 	@OriginalMember(owner = "client!bj", name = "<init>", descriptor = "(III)V")
-	public Tile(@OriginalArg(0) int level, @OriginalArg(1) int x, @OriginalArg(2) int y) {
-		this.y = y;
+	public Tile(@OriginalArg(0) int level, @OriginalArg(1) int x, @OriginalArg(2) int z) {
+		this.z = z;
 		this.plane = this.level = level;
 		this.x = x;
 	}

--- a/client/src/main/java/rt4/Wall.java
+++ b/client/src/main/java/rt4/Wall.java
@@ -22,7 +22,7 @@ public final class Wall {
 	public int anInt3049;
 
 	@OriginalMember(owner = "client!jh", name = "o", descriptor = "I")
-	public int anInt3051;
+	public int yFine;
 
 	@OriginalMember(owner = "client!jh", name = "q", descriptor = "I")
 	public int anInt3052;

--- a/client/src/main/java/rt4/WallDecor.java
+++ b/client/src/main/java/rt4/WallDecor.java
@@ -16,7 +16,7 @@ public final class WallDecor {
 	public int xFine;
 
 	@OriginalMember(owner = "client!df", name = "f", descriptor = "I")
-	public int anInt1391;
+	public int yFine;
 
 	@OriginalMember(owner = "client!df", name = "g", descriptor = "I")
 	public int zOffset;

--- a/client/src/main/java/rt4/client.java
+++ b/client/src/main/java/rt4/client.java
@@ -322,7 +322,7 @@ public final class client extends GameShell {
 		if (gameState == 0) {
 			LoadingBarAwt.clear();
 		}
-		if (gameState == 30) {
+		if (gameState == 25) {
 			PluginRepository.OnLogin();
 		}
 		if (arg0 == 40) {

--- a/client/src/main/java/rt4/client.java
+++ b/client/src/main/java/rt4/client.java
@@ -1589,8 +1589,9 @@ public final class client extends GameShell {
 			@Pc(24) GregorianCalendar gregorianCalendar = new GregorianCalendar();
 			MiniMenu.gregorianDateSeed = gregorianCalendar.get(Calendar.HOUR_OF_DAY) * 600 + gregorianCalendar.get(Calendar.MINUTE) * 10 + gregorianCalendar.get(Calendar.SECOND) / 6;
 			aRandom1.setSeed(MiniMenu.gregorianDateSeed);
-			PluginRepository.Update();
+			PluginRepository.Tick();
 		}
+		PluginRepository.Update();
 		this.js5NetworkLoop();
 		if (js5MasterIndex != null) {
 			js5MasterIndex.method179();

--- a/client/src/main/java/rt4/client.java
+++ b/client/src/main/java/rt4/client.java
@@ -1295,7 +1295,7 @@ public final class client extends GameShell {
 		}
 		@Pc(98) int percentage;
 		if (mainLoadState == 10) {
-			LightingManager.method2392();
+			LightingManager.setSize();
 			for (percentage = 0; percentage < 4; percentage++) {
 				PathFinder.collisionMaps[percentage] = new CollisionMap(104, 104);
 			}

--- a/plugin-playground/build.gradle
+++ b/plugin-playground/build.gradle
@@ -43,15 +43,15 @@ public class plugin extends Plugin {
     public void Init() {
         //Init() is called when the plugin is loaded
     }
-    
-    @Override
-    public void Update(long deltaTime) {
-        //Update() is called once per game loop, with deltaTime being the time since last loop.
-    }
  
     @Override
     public void Tick() {
         //Tick() is called once per tick (600ms)
+    }
+    
+    @Override
+    public void Update(long deltaTime) {
+        //Update() is called once per game loop, with deltaTime being the time since last loop.
     }
     
     @Override
@@ -85,13 +85,13 @@ class plugin : Plugin() {
     override fun Init() {
         //Init() is called when the plugin is loaded
     }
-    
-    override fun Update(deltaTime: Long) {
-        //Update() is called once per game loop, with deltaTime being the time since last loop.
-    }
  
     override fun Tick() {
         //Tick() is called once per tick (600ms)
+    }
+    
+    override fun Update(deltaTime: Long) {
+        //Update() is called once per game loop, with deltaTime being the time since last loop.
     }
     
     override fun Draw() {

--- a/plugin-playground/build.gradle
+++ b/plugin-playground/build.gradle
@@ -43,15 +43,20 @@ public class plugin extends Plugin {
     public void Init() {
         //Init() is called when the plugin is loaded
     }
+    
+    @Override
+    public void Update(long deltaTime) {
+        //Update() is called once per game loop, with deltaTime being the time since last loop.
+    }
  
     @Override
-    public void Update() {
-        //Update() is called once per tick (600ms)
+    public void Tick() {
+        //Tick() is called once per tick (600ms)
     }
     
     @Override
-    public void Draw(long deltaTime) {
-        //Draw() is called once per frame, with deltaTime being the time since last frame.
+    public void Draw() {
+        //Draw() is called once per frame
     }
  
     //Check the source of plugin.Plugin for more methods you can override! Happy hacking! <3
@@ -80,13 +85,17 @@ class plugin : Plugin() {
     override fun Init() {
         //Init() is called when the plugin is loaded
     }
+    
+    override fun Update(deltaTime: Long) {
+        //Update() is called once per game loop, with deltaTime being the time since last loop.
+    }
  
-    override fun Update() {
-        //Update() is called once per tick (600ms)
+    override fun Tick() {
+        //Tick() is called once per tick (600ms)
     }
     
-    override fun Draw(deltaTime: Long) {
-        //Draw() is called once per frame, with deltaTime being the time since last frame.
+    override fun Draw() {
+        //Draw() is called once per frame
     }
  
     //Check the source of plugin.Plugin for more methods you can override! Happy hacking! <3

--- a/plugin-playground/src/main/java/InterfaceDebugPlugin/plugin.java
+++ b/plugin-playground/src/main/java/InterfaceDebugPlugin/plugin.java
@@ -58,7 +58,7 @@ public class plugin extends Plugin {
     }
 
     @Override
-    public void Draw(long timeDelta) {
+    public void Draw() {
        if (!isEnabled) return;
 
        StringBuilder sb = new StringBuilder();

--- a/plugin-playground/src/main/java/VarpLogPlugin/plugin.java
+++ b/plugin-playground/src/main/java/VarpLogPlugin/plugin.java
@@ -42,7 +42,7 @@ public class plugin extends Plugin {
     }
 
     @Override
-    public void Draw(long timeDelta) {
+    public void Draw() {
         if (!isEnabled) return;
 
         int startX = 10;

--- a/plugin-playground/src/main/kotlin/AudioQOL/plugin.kt
+++ b/plugin-playground/src/main/kotlin/AudioQOL/plugin.kt
@@ -19,7 +19,7 @@ class plugin : Plugin() {
     var isMute = false
     var lastVolumes: Triple<Int,Int,Int>? = null
 
-    override fun Update() {
+    override fun Tick() {
         if (isMute) return
         API.StoreData("sound-vol", API.GetSoundVolume())
         API.StoreData("music-vol", API.GetMusicVolume())

--- a/plugin-playground/src/main/kotlin/BasicInputQOL/plugin.kt
+++ b/plugin-playground/src/main/kotlin/BasicInputQOL/plugin.kt
@@ -4,37 +4,76 @@ import plugin.Plugin
 import plugin.annotations.PluginMeta
 import plugin.api.*
 import rt4.Keyboard
-import java.awt.event.*
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.awt.event.MouseWheelEvent
+import java.awt.event.MouseWheelListener
 import javax.swing.SwingUtilities
 
 @PluginMeta(
-   author = "Ceikry",
+   author = "Ceikry, Enova",
    description = "Provides some basic input QOL like scroll zoom, middle click panning, etc.",
-   version = 1.0
+   version = 1.1
 )
 class plugin : Plugin() {
     private var cameraDebugEnabled = false
     private var mouseDebugEnabled = false
+    private var minZoomKey = "min-zoom";
+    private var maxZoomKey = "max-zoom";
+    private var defaultZoomKey = "default-zoom";
 
     companion object {
         private var lastMouseWheelX = 0
         private var lastMouseWheelY = 0
+        private var minZoom = 200;
+        private var maxZoom = 1200;
         private val defaultCameraPYZ = Triple(128.0, 0.0, 600)
     }
 
     override fun Init() {
+        minZoom = API.GetData(minZoomKey) as? Int ?: minZoom
+        maxZoom = API.GetData(maxZoomKey) as? Int ?: maxZoom
         API.AddMouseListener(MouseCallbacks)
         API.AddMouseWheelListener(MouseWheelCallbacks)
     }
 
     override fun ProcessCommand(commandStr: String?, args: Array<out String>?) {
         commandStr ?: return
+
+        when(commandStr) {
+            "::minZoom" -> {
+                args ?: return
+                minZoom = args[0].toInt()
+                API.StoreData(minZoomKey, minZoom)
+            }
+            "::maxZoom" -> {
+                args ?: return
+                maxZoom = args[0].toInt()
+                API.StoreData(maxZoomKey, maxZoom)
+            }
+        }
+
         if (API.PlayerHasPrivilege(Privileges.JMOD)) {
             when(commandStr) {
                 "::mousedebug" -> mouseDebugEnabled = !mouseDebugEnabled
                 "::cameradebug" -> cameraDebugEnabled = !cameraDebugEnabled
             }
         }
+    }
+
+    override fun Tick() {
+        if (!API.IsLoggedIn())
+            return;
+
+        storeDefaultZoom()
+    }
+
+    private fun storeDefaultZoom() {
+        API.StoreData(defaultZoomKey, API.GetCameraZoom())
+    }
+
+    private fun loadDefaultZoom() {
+        API.SetCameraZoom(API.GetData(defaultZoomKey) as Int, minZoom, maxZoom)
     }
 
     override fun Draw() {
@@ -60,6 +99,14 @@ class plugin : Plugin() {
         }
     }
 
+    override fun OnLogin() {
+        loadDefaultZoom()
+    }
+
+    override fun OnLogout() {
+        storeDefaultZoom()
+    }
+
     object MouseWheelCallbacks : MouseWheelListener {
         override fun mouseWheelMoved(e: MouseWheelEvent?) {
             e ?: return
@@ -67,7 +114,7 @@ class plugin : Plugin() {
                 val previous = API.GetPreviousMouseWheelRotation()
                 val current = API.GetMouseWheelRotation()
                 val diff = current - previous
-                API.UpdateCameraZoom(diff)
+                API.UpdateCameraZoom(diff, minZoom, maxZoom)
             }
         }
     }

--- a/plugin-playground/src/main/kotlin/BasicInputQOL/plugin.kt
+++ b/plugin-playground/src/main/kotlin/BasicInputQOL/plugin.kt
@@ -73,7 +73,9 @@ class plugin : Plugin() {
     }
 
     private fun loadDefaultZoom() {
-        API.SetCameraZoom(API.GetData(defaultZoomKey) as Int, minZoom, maxZoom)
+        val zoom: Int = API.GetData(defaultZoomKey) as? Int ?: return
+
+        API.SetCameraZoom(zoom, minZoom, maxZoom)
     }
 
     override fun Draw() {

--- a/plugin-playground/src/main/kotlin/BasicInputQOL/plugin.kt
+++ b/plugin-playground/src/main/kotlin/BasicInputQOL/plugin.kt
@@ -37,7 +37,7 @@ class plugin : Plugin() {
         }
     }
 
-    override fun Draw(timeDelta: Long) {
+    override fun Draw() {
         if (mouseDebugEnabled) {
             API.DrawText(
                 FontType.SMALL,

--- a/plugin-playground/src/main/kotlin/LoginTimer/plugin.kt
+++ b/plugin-playground/src/main/kotlin/LoginTimer/plugin.kt
@@ -40,7 +40,7 @@ class plugin : Plugin() {
         displayMessageCounter = 0
     }
 
-    override fun Draw(timeDelta: Long) {
+    override fun Update(deltaTime: Long) {
         if (component == null)
             return
         when (timeMode) {

--- a/plugin-playground/src/main/kotlin/MiniMenuQOL/plugin.kt
+++ b/plugin-playground/src/main/kotlin/MiniMenuQOL/plugin.kt
@@ -22,7 +22,7 @@ class plugin : Plugin() {
         }
     }
 
-    override fun Draw(timeDelta: Long) {
+    override fun Draw() {
         if (!debugEnabled) return
         val sb = StringBuilder()
         val entries = API.GetMiniMenuEntries()

--- a/plugin-playground/src/main/kotlin/RenderSettings/plugin.kt
+++ b/plugin-playground/src/main/kotlin/RenderSettings/plugin.kt
@@ -1,0 +1,37 @@
+package RenderSettings
+
+import plugin.Plugin
+import plugin.annotations.PluginMeta
+import plugin.api.API
+import rt4.GlobalConfig
+
+@PluginMeta(
+    author = "Enova",
+    description = "Provides configuration for various parts of the game's rendering like render distance.",
+    version = 1.0
+)
+class plugin : Plugin() {
+    private var viewDistanceKey = "view-distance"
+
+    override fun Init() {
+        GlobalConfig.TILE_DISTANCE = API.GetData(viewDistanceKey) as? Int ?: return;
+        GlobalConfig.VIEW_DISTANCE = GlobalConfig.TILE_DISTANCE * 128
+    }
+
+    override fun ProcessCommand(commandStr: String?, args: Array<out String>?) {
+        when(commandStr) {
+            "::viewDistance" -> {
+                args?: return
+                val distanceArg = args[0].toInt();
+                if (distanceArg > 0) {
+                    API.StoreData(viewDistanceKey, distanceArg)
+                    printRestartWarning()
+                }
+            }
+        }
+    }
+
+    private fun printRestartWarning() {
+        API.SendMessage("Configuration updated. Changes won't apply until you restart the game.")
+    }
+}

--- a/plugin-playground/src/main/kotlin/RenderSettings/plugin.kt
+++ b/plugin-playground/src/main/kotlin/RenderSettings/plugin.kt
@@ -16,6 +16,7 @@ class plugin : Plugin() {
     override fun Init() {
         GlobalConfig.TILE_DISTANCE = API.GetData(viewDistanceKey) as? Int ?: return;
         GlobalConfig.VIEW_DISTANCE = GlobalConfig.TILE_DISTANCE * 128
+        GlobalConfig.VIEW_FADE_DISTANCE = GlobalConfig.TILE_DISTANCE.toFloat() / 28.0f * 256.0f
     }
 
     override fun ProcessCommand(commandStr: String?, args: Array<out String>?) {

--- a/plugin-playground/src/main/kotlin/SlayerTrackerPlugin/plugin.kt
+++ b/plugin-playground/src/main/kotlin/SlayerTrackerPlugin/plugin.kt
@@ -31,7 +31,7 @@ class plugin : Plugin() {
     var slayerTaskAmount = 0
     var curSprite: Sprite? = null
 
-    override fun Draw(deltaTime: Long) {
+    override fun Draw() {
         if (slayerTaskAmount == 0 || slayerTaskID == -1) return
 
         API.FillRect(posX, posY, boxWidth, boxHeight, boxColor, boxOpacity)

--- a/plugin-playground/src/main/kotlin/XPDropPlugin/plugin.kt
+++ b/plugin-playground/src/main/kotlin/XPDropPlugin/plugin.kt
@@ -21,7 +21,7 @@ class plugin : Plugin() {
     private val activeGains = ArrayList<XPGain>()
     private var lastGain = 0L
 
-    override fun Draw(deltaTime: Long) {
+    override fun Update(deltaTime: Long) {
         if (System.currentTimeMillis() - lastGain >= displayTimeout && activeGains.isEmpty())
             return
 
@@ -38,7 +38,20 @@ class plugin : Plugin() {
             if (gain.currentPos <= drawClear) {
                 removeList.add(gain)
                 totalXp += gain.xp
-            } else if (gain.currentPos <= drawStart){
+            }
+        }
+
+        activeGains.removeAll(removeList.toSet())
+    }
+
+    override fun Draw() {
+        var posX = API.GetWindowDimensions().width / 2
+
+        if (API.GetWindowMode() == WindowMode.FIXED)
+            posX += 60
+
+        for (gain in activeGains) {
+            if (gain.currentPos <= drawStart) {
                 val sprite = XPSprites.getSpriteForSkill(skillId = gain.skill)
                 sprite?.render(posX - 25, gain.currentPos - 20)
                 API.DrawText(
@@ -51,8 +64,6 @@ class plugin : Plugin() {
                 )
             }
         }
-
-        activeGains.removeAll(removeList.toSet())
     }
 
     override fun OnXPUpdate(skill: Int, xp: Int) {


### PR DESCRIPTION
Currently, even with BasicInputQOL you cannot zoom out very far and it makes the game feel very claustrophobic and makes navigation more cumbersome than it should be. I set out to rectify this problem and ended up resolving a lot of other things along the way.

- I've reworked the game's rendering code to be able to handle the camera being outside of the world bounds (SceneGraph.width/length, or below 0 on either axis). This required:
  - Adding more sanity checks to the code that adds the visible tiles to the stack
  - Adjusting the view limit sanity checks to have 1 be the minimum, instead (I would like to improve this in the future but currently the only functional difference in rendering this causes occurs if the camera is out of bounds so it's not important.)
  - Renaming and deobbing a TON of rendering code
- I've adjusted the Plugin API to allow the user control of their camera. This entailed:
  - Modifying the Plugin API to let you specify your own minimum and maximum Camera.ZOOM values with an overload.
  - Updating the BasicInputQOL plugin to allow you to customize the minimum and maximum zoom with some chat commands.
  - Adding a new plugin called RenderSettings that let's you increase/decrease the game's TILE_DISTANCE and it's dependent variables with a chat command.
- I've overhauled the Plugin API to fix a few bugs that existed in it. This involved:
  - Call OnLogin when the state is 25 instead of 30 as OnLogin was never getting called before
  - Adjust getTileHeight in SceneGraph and clampCameraAngle in Camera to be able to catch a race condition that's caused by API trying to clamp the camera angle on another thread (Honestly this should just be done manually because a lot of redundant code is still run)
  - Rename the current Plugin Update() to Tick() so that it indicates better the function of the override. This forced me to change:
    - All the existing plugins to use Tick instead of Update
  - Add a new Update() method that gets called every game loop so that plugins can check for game state and other such things. This meant:
    - Moving the deltaTime parameter to Update instead of Draw as Draw shouldn't be using it
    - Adjusting XPDropPlugin to use Update for moving the new gains and Draw to actually display them, for consistency.