### PR TITLE
Change window title based on what it's connected to.

### DIFF
--- a/client/src/main/java/rt4/GameShell.java
+++ b/client/src/main/java/rt4/GameShell.java
@@ -680,7 +680,16 @@ public abstract class GameShell extends Applet implements Runnable, FocusListene
 			topMargin = 0;
 			instance = this;
 			frame = new Frame();
-			frame.setTitle("Jagex");
+			String title = "Jagex";
+			if (GlobalJsonConfig.instance != null) {
+				String hostname = GlobalJsonConfig.instance.ip_management;
+				switch(hostname) {
+					case "play.2009scape.org": title = "2009Scape"; break;
+					case "test.2009scape.org": title = "2009Scape [Test]"; break;
+					case "localhost": title = "2009Scape [Local]"; break;
+				}
+			}
+			frame.setTitle(title);
 			frame.setResizable(true);
 			frame.addWindowListener(this);
 			frame.setVisible(true);


### PR DESCRIPTION
Made this as clean as possible. This solves an issue that really only I have, but it's not a regression so... yeah.

Changes the window title based on what it's connected to:
- play.2009scape.org: "2009Scape"
- test.2009scape.org: "2009Scape [Test]"
- localhost: "2009Scape [Local]
- else: "Jagex"